### PR TITLE
PR1: Exchange core + Kalshi adapter refactor

### DIFF
--- a/neural/__init__.py
+++ b/neural/__init__.py
@@ -17,9 +17,19 @@ __author__ = "Neural Contributors"
 __license__ = "MIT"
 
 import warnings
+from types import ModuleType
 from typing import Set  # noqa: UP035
 
-from neural import analysis, auth, data_collection, deployment, trading
+from . import analysis, auth, data_collection, exchanges, trading
+
+deployment: ModuleType | None
+try:
+    from . import deployment as deployment
+except ModuleNotFoundError as exc:
+    # Keep package importable when optional deployment deps (docker SDK) are absent.
+    if getattr(exc, "name", None) != "docker":
+        raise
+    deployment = None
 
 # Track which experimental features have been used
 _experimental_features_used: set[str] = set()
@@ -65,6 +75,7 @@ __all__ = [
     "data_collection",
     "analysis",
     "trading",
+    "exchanges",
     "deployment",  # v0.4.0: Docker deployment module (experimental)
     "_warn_experimental",  # For internal use by modules
 ]

--- a/neural/exchanges/__init__.py
+++ b/neural/exchanges/__init__.py
@@ -1,0 +1,31 @@
+from .base import BaseExchangeAdapter, ExchangeAdapter
+from .registry import ExchangeRegistry, registry
+from .types import (
+    ExchangeCapabilities,
+    ExchangeName,
+    NormalizedMarket,
+    NormalizedOrderRequest,
+    NormalizedOrderResult,
+    NormalizedPosition,
+    NormalizedQuote,
+    OrderSide,
+    OrderType,
+    TradingPolicy,
+)
+
+__all__ = [
+    "ExchangeAdapter",
+    "BaseExchangeAdapter",
+    "ExchangeRegistry",
+    "registry",
+    "ExchangeName",
+    "OrderSide",
+    "OrderType",
+    "TradingPolicy",
+    "ExchangeCapabilities",
+    "NormalizedMarket",
+    "NormalizedQuote",
+    "NormalizedOrderRequest",
+    "NormalizedOrderResult",
+    "NormalizedPosition",
+]

--- a/neural/exchanges/base.py
+++ b/neural/exchanges/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import date
 
 from .types import (
     ExchangeCapabilities,
@@ -63,9 +64,20 @@ class BaseExchangeAdapter(ExchangeAdapter):
     """Shared policy guards for live trading adapters."""
 
     _daily_notional_used: float
+    _daily_notional_date: date
 
     def __init__(self) -> None:
         self._daily_notional_used = 0.0
+        self._daily_notional_date = self._current_day()
+
+    def _current_day(self) -> date:
+        return date.today()
+
+    def _rollover_daily_notional_if_needed(self) -> None:
+        current_day = self._current_day()
+        if self._daily_notional_date != current_day:
+            self._daily_notional_date = current_day
+            self._daily_notional_used = 0.0
 
     def _enforce_policy(self, order: NormalizedOrderRequest, policy: TradingPolicy | None) -> None:
         if policy is None:
@@ -84,6 +96,7 @@ class BaseExchangeAdapter(ExchangeAdapter):
             )
 
         if policy.max_daily_notional is not None:
+            self._rollover_daily_notional_if_needed()
             projected = self._daily_notional_used + notional
             if projected > policy.max_daily_notional:
                 raise ValueError(

--- a/neural/exchanges/base.py
+++ b/neural/exchanges/base.py
@@ -79,9 +79,9 @@ class BaseExchangeAdapter(ExchangeAdapter):
             self._daily_notional_date = current_day
             self._daily_notional_used = 0.0
 
-    def _enforce_policy(self, order: NormalizedOrderRequest, policy: TradingPolicy | None) -> None:
+    def _enforce_policy(self, order: NormalizedOrderRequest, policy: TradingPolicy | None) -> float:
         if policy is None:
-            return
+            return 0.0
         if not policy.live_enabled:
             raise PermissionError("Live trading is disabled by TradingPolicy.")
         if not policy.market_allowed(order.market_id):
@@ -104,4 +104,10 @@ class BaseExchangeAdapter(ExchangeAdapter):
                     f"{policy.max_daily_notional:.4f}."
                 )
 
+        return notional
+
+    def _record_daily_notional(self, notional: float) -> None:
+        if notional <= 0:
+            return
+        self._rollover_daily_notional_if_needed()
         self._daily_notional_used += notional

--- a/neural/exchanges/base.py
+++ b/neural/exchanges/base.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .types import (
+    ExchangeCapabilities,
+    ExchangeName,
+    NormalizedMarket,
+    NormalizedOrderRequest,
+    NormalizedOrderResult,
+    NormalizedPosition,
+    NormalizedQuote,
+    TradingPolicy,
+)
+
+
+class ExchangeAdapter(ABC):
+    """Contract for exchange integrations used by TradingClient."""
+
+    name: ExchangeName
+
+    @abstractmethod
+    def capabilities(self) -> ExchangeCapabilities:
+        """Return adapter capabilities."""
+
+    @abstractmethod
+    def list_markets(
+        self, *, sport: str | None = None, limit: int = 100, sports_only: bool = True
+    ) -> list[NormalizedMarket]:
+        """List markets for discovery and strategy selection."""
+
+    @abstractmethod
+    def get_quote(self, market_id: str) -> NormalizedQuote:
+        """Fetch best bid/ask quote for a market."""
+
+    @abstractmethod
+    def place_order(
+        self,
+        order: NormalizedOrderRequest,
+        *,
+        policy: TradingPolicy | None = None,
+    ) -> NormalizedOrderResult:
+        """Place an order on the exchange."""
+
+    @abstractmethod
+    def cancel_order(self, order_id: str) -> NormalizedOrderResult:
+        """Cancel an existing order."""
+
+    @abstractmethod
+    def get_order_status(self, order_id: str) -> NormalizedOrderResult:
+        """Fetch order status."""
+
+    @abstractmethod
+    def get_positions(self) -> list[NormalizedPosition]:
+        """Fetch open positions."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close network resources."""
+
+
+class BaseExchangeAdapter(ExchangeAdapter):
+    """Shared policy guards for live trading adapters."""
+
+    _daily_notional_used: float
+
+    def __init__(self) -> None:
+        self._daily_notional_used = 0.0
+
+    def _enforce_policy(self, order: NormalizedOrderRequest, policy: TradingPolicy | None) -> None:
+        if policy is None:
+            return
+        if not policy.live_enabled:
+            raise PermissionError("Live trading is disabled by TradingPolicy.")
+        if not policy.market_allowed(order.market_id):
+            raise PermissionError(f"Market {order.market_id} is not allowlisted.")
+
+        notional = order.quantity * (order.price if order.price is not None else 1.0)
+
+        if policy.max_notional_per_order is not None and notional > policy.max_notional_per_order:
+            raise ValueError(
+                f"Order notional {notional:.4f} exceeds per-order cap "
+                f"{policy.max_notional_per_order:.4f}."
+            )
+
+        if policy.max_daily_notional is not None:
+            projected = self._daily_notional_used + notional
+            if projected > policy.max_daily_notional:
+                raise ValueError(
+                    f"Projected daily notional {projected:.4f} exceeds cap "
+                    f"{policy.max_daily_notional:.4f}."
+                )
+
+        self._daily_notional_used += notional

--- a/neural/exchanges/registry.py
+++ b/neural/exchanges/registry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from .base import ExchangeAdapter
+from .types import ExchangeName
+
+Factory = Callable[..., ExchangeAdapter]
+
+
+class ExchangeRegistry:
+    def __init__(self) -> None:
+        self._factories: dict[ExchangeName, Factory] = {}
+
+    def register(self, name: ExchangeName, factory: Factory) -> None:
+        self._factories[name] = factory
+
+    def create(self, name: ExchangeName, **kwargs: Any) -> ExchangeAdapter:
+        if name not in self._factories:
+            raise ValueError(f"Exchange adapter not registered: {name}")
+        return self._factories[name](**kwargs)
+
+    def names(self) -> list[str]:
+        return sorted(self._factories.keys())
+
+
+registry = ExchangeRegistry()

--- a/neural/exchanges/types.py
+++ b/neural/exchanges/types.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+ExchangeName = Literal["kalshi", "polymarket_us"]
+OrderSide = Literal["buy_yes", "buy_no", "sell_yes", "sell_no"]
+OrderType = Literal["market", "limit"]
+
+
+@dataclass(slots=True)
+class NormalizedMarket:
+    market_id: str
+    ticker: str
+    title: str
+    status: str = "open"
+    yes_price: float | None = None
+    no_price: float | None = None
+    category: str | None = None
+    sport: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class NormalizedQuote:
+    market_id: str
+    yes_bid: float | None = None
+    yes_ask: float | None = None
+    no_bid: float | None = None
+    no_ask: float | None = None
+    last_price: float | None = None
+    volume: float | None = None
+    timestamp: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class NormalizedOrderRequest:
+    market_id: str
+    side: OrderSide
+    quantity: int
+    order_type: OrderType = "limit"
+    price: float | None = None
+    idempotency_key: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class NormalizedOrderResult:
+    success: bool
+    status: str
+    order_id: str | None = None
+    message: str | None = None
+    filled_price: float | None = None
+    filled_quantity: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class NormalizedPosition:
+    market_id: str
+    side: Literal["yes", "no"]
+    quantity: int
+    entry_price: float | None = None
+    current_price: float | None = None
+    unrealized_pnl: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TradingPolicy:
+    live_enabled: bool = False
+    allowed_markets: list[str] | None = None
+    max_notional_per_order: float | None = None
+    max_daily_notional: float | None = None
+
+    def market_allowed(self, market_id: str) -> bool:
+        if not self.allowed_markets:
+            return True
+        return market_id in self.allowed_markets
+
+
+@dataclass(slots=True)
+class ExchangeCapabilities:
+    read: bool
+    paper: bool
+    live: bool
+    streaming: bool
+
+    def as_dict(self) -> dict[str, bool]:
+        return {
+            "read": self.read,
+            "paper": self.paper,
+            "live": self.live,
+            "streaming": self.streaming,
+        }

--- a/neural/trading/__init__.py
+++ b/neural/trading/__init__.py
@@ -1,7 +1,18 @@
-"""High-level trading utilities for the Neural Kalshi SDK."""
+"""High-level trading utilities for the Neural prediction-market SDK."""
+
+from neural.exchanges.types import (
+    ExchangeCapabilities,
+    NormalizedMarket,
+    NormalizedOrderRequest,
+    NormalizedOrderResult,
+    NormalizedPosition,
+    NormalizedQuote,
+    TradingPolicy,
+)
 
 from .client import TradingClient
 from .fix import FIXConnectionConfig, KalshiFIXClient
+from .kalshi_adapter import KalshiAdapter
 from .paper_client import PaperTradingClient, create_paper_trading_client
 from .paper_portfolio import PaperPortfolio, Position, Trade
 from .paper_report import PaperTradingReporter, create_report
@@ -9,6 +20,7 @@ from .websocket import KalshiWebSocketClient
 
 __all__ = [
     "TradingClient",
+    "KalshiAdapter",
     "KalshiWebSocketClient",
     "KalshiFIXClient",
     "FIXConnectionConfig",
@@ -19,4 +31,11 @@ __all__ = [
     "Trade",
     "PaperTradingReporter",
     "create_report",
+    "TradingPolicy",
+    "ExchangeCapabilities",
+    "NormalizedMarket",
+    "NormalizedQuote",
+    "NormalizedOrderRequest",
+    "NormalizedOrderResult",
+    "NormalizedPosition",
 ]

--- a/neural/trading/client.py
+++ b/neural/trading/client.py
@@ -50,7 +50,7 @@ class _CompatMarkets:
         limit = int(kwargs.get("limit", 100))
         sports_only = bool(kwargs.get("sports_only", True))
         markets = self._client.list_markets(sport=sport, limit=limit, sports_only=sports_only)
-        return {"markets": [serialize_value(m) for m in markets]}
+        return {"markets": markets}
 
 
 class _CompatPortfolio:
@@ -58,8 +58,7 @@ class _CompatPortfolio:
         self._client = client
 
     def get_positions(self) -> dict[str, Any]:
-        rows = [serialize_value(p) for p in self._client.get_positions()]
-        return {"positions": rows}
+        return {"positions": self._client.get_positions()}
 
 
 class _CompatExchange:
@@ -297,7 +296,7 @@ def _run_coro_sync(coro: Any) -> Any:
         except BaseException as exc:
             error["exc"] = exc
 
-    thread = threading.Thread(target=_runner, daemon=True)
+    thread = threading.Thread(target=_runner)
     thread.start()
     thread.join()
 

--- a/neural/trading/client.py
+++ b/neural/trading/client.py
@@ -250,7 +250,13 @@ class TradingClient:
         paper_client = self._paper_client_instance()
         if side.startswith("sell_"):
             base_side = "yes" if side.endswith("yes") else "no"
-            return serialize_value(paper_client.close_position(market_id=market_id, side=base_side))
+            return serialize_value(
+                paper_client.close_position(
+                    market_id=market_id,
+                    side=base_side,
+                    quantity=quantity,
+                )
+            )
 
         base_side = "yes" if side.endswith("yes") else "no"
         return _run_coro_sync(

--- a/neural/trading/client.py
+++ b/neural/trading/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from typing import Any
 
 from neural.analysis.risk import Position
@@ -286,7 +287,20 @@ def _run_coro_sync(coro: Any) -> Any:
         asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.run(coro)
-    raise RuntimeError(
-        "Cannot execute sync paper-trading call inside a running event loop. "
-        "Use async PaperTradingClient APIs directly."
-    )
+
+    result: dict[str, Any] = {}
+    error: dict[str, BaseException] = {}
+
+    def _runner() -> None:
+        try:
+            result["value"] = asyncio.run(coro)
+        except BaseException as exc:
+            error["exc"] = exc
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    thread.join()
+
+    if "exc" in error:
+        raise error["exc"]
+    return result.get("value")

--- a/neural/trading/client.py
+++ b/neural/trading/client.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass, field
-from typing import Any, Protocol
+import asyncio
+from typing import Any
 
-from neural.auth.env import get_api_key_id, get_base_url, get_private_key_material
+from neural.analysis.risk import Position
+from neural.exchanges.registry import registry
+from neural.exchanges.types import (
+    ExchangeName,
+    NormalizedOrderRequest,
+    TradingPolicy,
+)
+from neural.trading.paper_client import PaperTradingClient
+
+from .kalshi_adapter import KalshiAdapter, KalshiClientFactory, serialize_value
 
 
-class _KalshiClientFactory(Protocol):
-    def __call__(self, **kwargs: Any) -> Any: ...
-
-
-def _default_client_factory() -> _KalshiClientFactory:
-    """Return a factory that builds the modern kalshi-python Client lazily.
-
-    Keeping this import inside a function prevents import-time crashes if the
-    optional dependency isn't installed. Errors surface only when constructing
-    TradingClient, with a helpful message.
-    """
+def _default_client_factory() -> KalshiClientFactory:
+    """Return a factory that builds the modern kalshi-python Client lazily."""
 
     try:
         from kalshi_python import KalshiClient as Client  # type: ignore
@@ -27,106 +26,169 @@ def _default_client_factory() -> _KalshiClientFactory:
         ) from exc
 
     def _factory(**kwargs: Any) -> Any:
-        # Create configuration for kalshi_python v2
         from kalshi_python.configuration import Configuration
 
-        # Create configuration object (use default host with correct API path)
         config = Configuration()
-        # Don't override host - Configuration default has correct /trade-api/v2 path
-
-        # Set authentication attributes directly (v2 pattern)
         config.api_key_id = kwargs.get("api_key_id")
         config.private_key_pem = kwargs.get("private_key_pem")
-
         return Client(configuration=config)  # type: ignore[misc]
 
     return _factory
 
 
-def _serialize(obj: Any) -> Any:
-    # Normalize common pydantic-like models to dict for a stable SDK surface
-    if hasattr(obj, "model_dump"):
-        try:
-            return obj.model_dump()
-        except Exception:
-            pass
-    if isinstance(obj, dict):
-        return {k: _serialize(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        ctor: Callable[[Any], Any] = list if isinstance(obj, list) else tuple
-        return ctor(_serialize(v) for v in obj)
-    return obj
+# Backward-compatible alias used by existing tests and imports.
+_KalshiClientFactory = KalshiClientFactory
 
 
-class _ServiceProxy:
-    """Thin proxy around a sub-API to provide stable call/return behavior."""
+class _CompatMarkets:
+    def __init__(self, client: TradingClient) -> None:
+        self._client = client
 
-    def __init__(self, api: Any):
-        self._api = api
-
-    def __getattr__(self, name: str) -> Callable[..., Any]:
-        target = getattr(self._api, name)
-        if not callable(target):
-            return target
-
-        def call(*args: Any, **kwargs: Any) -> Any:
-            result = target(*args, **kwargs)
-            return _serialize(result)
-
-        call.__name__ = getattr(target, "__name__", name)
-        call.__doc__ = getattr(target, "__doc__", None)
-        return call
+    def get_markets(self, **kwargs: Any) -> dict[str, Any]:
+        sport = kwargs.get("sport") or kwargs.get("category")
+        limit = int(kwargs.get("limit", 100))
+        sports_only = bool(kwargs.get("sports_only", True))
+        markets = self._client.list_markets(sport=sport, limit=limit, sports_only=sports_only)
+        return {"markets": [serialize_value(m) for m in markets]}
 
 
-@dataclass(slots=True)
-class TradingClient:
-    """High-level Kalshi trading client using the modern kalshi-python API.
+class _CompatPortfolio:
+    def __init__(self, client: TradingClient) -> None:
+        self._client = client
 
-    - Lazy optional dependency import
-    - Explicit configuration via env/files
-    - Stable facade for portfolio, markets, exchange
-    - Dependency-injectable client factory for testing
-    - Optional risk management integration
-    """
+    def get_positions(self) -> dict[str, Any]:
+        rows = [serialize_value(p) for p in self._client.get_positions()]
+        return {"positions": rows}
 
-    api_key_id: str | None = None
-    private_key_pem: bytes | None = None
-    env: str | None = None
-    timeout: int = 15
-    client_factory: _KalshiClientFactory | None = None
-    risk_manager: Any = None  # Optional RiskManager instance
 
-    _client: Any = field(init=False)
-    portfolio: _ServiceProxy = field(init=False)
-    markets: _ServiceProxy = field(init=False)
-    exchange: _ServiceProxy = field(init=False)
+class _CompatExchange:
+    def __init__(self, client: TradingClient) -> None:
+        self._client = client
 
-    def __post_init__(self) -> None:
-        api_key = self.api_key_id or get_api_key_id()
-        priv_key = self.private_key_pem or get_private_key_material()
-        # Keep key material as bytes; callers/tests and crypto tooling expect bytes
-        priv_key_material = priv_key
-        base_url = get_base_url(self.env)
-
-        factory = self.client_factory or _default_client_factory()
-        self._client = factory(
-            base_url=base_url,
-            api_key_id=api_key,
-            private_key_pem=priv_key_material,
-            timeout=self.timeout,
+    def create_order(self, **kwargs: Any) -> dict[str, Any]:
+        result = self._client.place_order(
+            market_id=str(kwargs.get("market_id") or kwargs.get("ticker")),
+            side=str(kwargs.get("side", "yes")),
+            quantity=int(kwargs.get("quantity") or kwargs.get("count") or 0),
+            price=kwargs.get("price"),
+            order_type=str(kwargs.get("type") or kwargs.get("order_type") or "limit"),
+            idempotency_key=kwargs.get("idempotency_key"),
+            policy=kwargs.get("policy"),
+            paper=bool(kwargs.get("paper", False)),
         )
+        return {"order": result}
 
-        # Map common sub-APIs with graceful fallback
-        self.portfolio = _ServiceProxy(getattr(self._client, "portfolio", self._client))
-        self.markets = _ServiceProxy(getattr(self._client, "markets", self._client))
-        self.exchange = _ServiceProxy(getattr(self._client, "exchange", self._client))
+
+def _ensure_adapters_registered() -> None:
+    if "kalshi" not in registry.names():
+        registry.register("kalshi", lambda **kwargs: KalshiAdapter(**kwargs))
+
+
+class TradingClient:
+    """Exchange-agnostic trading client with backward-compatible Kalshi defaults."""
+
+    def __init__(
+        self,
+        api_key_id: str | None = None,
+        private_key_pem: bytes | None = None,
+        env: str | None = None,
+        timeout: int = 15,
+        client_factory: _KalshiClientFactory | None = None,
+        risk_manager: Any = None,
+        *,
+        exchange: ExchangeName = "kalshi",
+        paper_trading: bool = False,
+        trading_policy: TradingPolicy | None = None,
+    ) -> None:
+        _ensure_adapters_registered()
+
+        self.exchange_name: ExchangeName = exchange
+        self.risk_manager = risk_manager
+        self.paper_trading = paper_trading
+        self.trading_policy = trading_policy or TradingPolicy()
+        self._paper_client: PaperTradingClient | None = None
+
+        if exchange == "kalshi":
+            factory = client_factory or _default_client_factory()
+            self._adapter = registry.create(
+                "kalshi",
+                api_key_id=api_key_id,
+                private_key_pem=private_key_pem,
+                env=env,
+                timeout=timeout,
+                client_factory=factory,
+            )
+        else:
+            raise ValueError(f"Exchange '{exchange}' is not registered yet")
+
+        self._client = getattr(self._adapter, "_client", self._adapter)
+        self.portfolio = getattr(self._adapter, "portfolio", _CompatPortfolio(self))
+        self.markets = getattr(self._adapter, "markets", _CompatMarkets(self))
+        self.exchange = getattr(self._adapter, "exchange", _CompatExchange(self))
+
+    def capabilities(self) -> dict[str, bool]:
+        return self._adapter.capabilities().as_dict()
+
+    def list_markets(
+        self, *, sport: str | None = None, limit: int = 100, sports_only: bool = True
+    ) -> list[dict[str, Any]]:
+        rows = self._adapter.list_markets(sport=sport, limit=limit, sports_only=sports_only)
+        return [serialize_value(row) for row in rows]
+
+    def get_quote(self, market_id: str) -> dict[str, Any]:
+        return serialize_value(self._adapter.get_quote(market_id))
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        return [serialize_value(p) for p in self._adapter.get_positions()]
+
+    def place_order(
+        self,
+        market_id: str,
+        side: str,
+        *,
+        quantity: int | None = None,
+        count: int | None = None,
+        order_type: str = "market",
+        price: float | None = None,
+        idempotency_key: str | None = None,
+        policy: TradingPolicy | None = None,
+        paper: bool | None = None,
+    ) -> dict[str, Any]:
+        qty = quantity if quantity is not None else count
+        if qty is None:
+            raise ValueError("quantity or count is required")
+
+        use_paper = self.paper_trading if paper is None else paper
+        normalized_side = _normalize_order_side(side)
+
+        if use_paper:
+            return self._place_paper_order(
+                market_id=market_id,
+                side=normalized_side,
+                quantity=qty,
+                order_type=order_type,
+                price=price,
+            )
+
+        order = NormalizedOrderRequest(
+            market_id=market_id,
+            side=normalized_side,
+            quantity=qty,
+            order_type="market" if order_type == "market" else "limit",
+            price=price,
+            idempotency_key=idempotency_key,
+        )
+        result = self._adapter.place_order(order, policy=policy or self.trading_policy)
+        return serialize_value(result)
+
+    def cancel_order(self, order_id: str) -> dict[str, Any]:
+        return serialize_value(self._adapter.cancel_order(order_id))
+
+    def get_order_status(self, order_id: str) -> dict[str, Any]:
+        return serialize_value(self._adapter.get_order_status(order_id))
 
     def close(self) -> None:
-        if hasattr(self._client, "close"):
-            try:
-                self._client.close()
-            except Exception:
-                pass
+        self._adapter.close()
 
     def __enter__(self) -> TradingClient:
         return self
@@ -135,55 +197,90 @@ class TradingClient:
         self.close()
 
     def place_order_with_risk(
-        self, market_id: str, side: str, quantity: int, stop_loss_config: Any = None, **order_kwargs
+        self,
+        market_id: str,
+        side: str,
+        quantity: int,
+        stop_loss_config: Any = None,
+        **order_kwargs: Any,
     ) -> Any:
-        """
-        Place an order with optional risk management.
+        result = self.place_order(
+            market_id=market_id,
+            side=side,
+            quantity=quantity,
+            order_type=str(order_kwargs.get("type") or order_kwargs.get("order_type") or "limit"),
+            price=order_kwargs.get("price"),
+            idempotency_key=order_kwargs.get("idempotency_key"),
+            policy=order_kwargs.get("policy"),
+            paper=order_kwargs.get("paper"),
+        )
 
-        Args:
-            market_id: Market identifier
-            side: "yes" or "no"
-            quantity: Order quantity
-            stop_loss_config: Optional stop-loss configuration
-            **order_kwargs: Additional order parameters
+        if self.risk_manager and stop_loss_config:
+            try:
+                import time
 
-        Returns:
-            Order result
-        """
-        # Place the order first
-        # Note: This assumes the exchange service has order methods
-        # The actual implementation depends on kalshi-python API
+                position = Position(
+                    market_id=market_id,
+                    side="yes" if _normalize_order_side(side).endswith("yes") else "no",
+                    quantity=quantity,
+                    entry_price=order_kwargs.get("price", 0.5),
+                    entry_time=time.time(),
+                    stop_loss=stop_loss_config,
+                )
+                self.risk_manager.add_position(position)
+            except Exception:
+                pass
 
-        try:
-            # Hypothetical order placement - adapt based on actual API
-            order_result = self.exchange.create_order(
-                market_id=market_id, side=side, quantity=quantity, **order_kwargs
+        return result
+
+    def _paper_client_instance(self) -> PaperTradingClient:
+        if self._paper_client is None:
+            self._paper_client = PaperTradingClient(save_trades=False)
+        return self._paper_client
+
+    def _place_paper_order(
+        self,
+        *,
+        market_id: str,
+        side: str,
+        quantity: int,
+        order_type: str,
+        price: float | None,
+    ) -> dict[str, Any]:
+        paper_client = self._paper_client_instance()
+        if side.startswith("sell_"):
+            base_side = "yes" if side.endswith("yes") else "no"
+            return serialize_value(paper_client.close_position(market_id=market_id, side=base_side))
+
+        base_side = "yes" if side.endswith("yes") else "no"
+        return _run_coro_sync(
+            paper_client.place_order(
+                market_id=market_id,
+                side=base_side,
+                quantity=quantity,
+                order_type=order_type,
+                price=price,
             )
+        )
 
-            # Register with risk manager if provided
-            if self.risk_manager and stop_loss_config:
-                try:
-                    import time
 
-                    from neural.analysis.risk import Position
+def _normalize_order_side(side: str) -> str:
+    normalized = side.lower().strip()
+    if normalized in {"yes", "buy_yes"}:
+        return "buy_yes"
+    if normalized in {"no", "buy_no"}:
+        return "buy_no"
+    if normalized in {"sell_yes", "sell_no"}:
+        return normalized
+    raise ValueError(f"Unsupported side: {side}")
 
-                    position = Position(
-                        market_id=market_id,
-                        side=side,
-                        quantity=quantity,
-                        entry_price=order_kwargs.get("price", 0.5),  # Default assumption
-                        entry_time=time.time(),
-                        stop_loss=stop_loss_config,
-                    )
-                    self.risk_manager.add_position(position)
-                except ImportError:
-                    pass  # Risk module not available
 
-            return order_result
-
-        except Exception as e:
-            # Log error and re-raise
-            import logging
-
-            logging.getLogger(__name__).error(f"Order placement failed: {e}")
-            raise
+def _run_coro_sync(coro: Any) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    raise RuntimeError(
+        "Cannot execute sync paper-trading call inside a running event loop. "
+        "Use async PaperTradingClient APIs directly."
+    )

--- a/neural/trading/kalshi_adapter.py
+++ b/neural/trading/kalshi_adapter.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, Protocol
+
+from neural.auth.env import get_api_key_id, get_base_url, get_private_key_material
+from neural.exchanges.base import BaseExchangeAdapter
+from neural.exchanges.types import (
+    ExchangeCapabilities,
+    NormalizedMarket,
+    NormalizedOrderRequest,
+    NormalizedOrderResult,
+    NormalizedPosition,
+    NormalizedQuote,
+    TradingPolicy,
+)
+
+
+class KalshiClientFactory(Protocol):
+    def __call__(self, **kwargs: Any) -> Any: ...
+
+
+def serialize_value(obj: Any) -> Any:
+    if is_dataclass(obj):
+        return asdict(obj)
+    if hasattr(obj, "model_dump"):
+        try:
+            return obj.model_dump()
+        except Exception:
+            pass
+    if isinstance(obj, dict):
+        return {k: serialize_value(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        ctor: Callable[[Any], Any] = list if isinstance(obj, list) else tuple
+        return ctor(serialize_value(v) for v in obj)
+    return obj
+
+
+class ServiceProxy:
+    """Thin proxy around a sub-API to provide stable call/return behavior."""
+
+    def __init__(self, api: Any):
+        self._api = api
+
+    def __getattr__(self, name: str) -> Callable[..., Any]:
+        target = getattr(self._api, name)
+        if not callable(target):
+            return target
+
+        def call(*args: Any, **kwargs: Any) -> Any:
+            return serialize_value(target(*args, **kwargs))
+
+        call.__name__ = getattr(target, "__name__", name)
+        call.__doc__ = getattr(target, "__doc__", None)
+        return call
+
+
+@dataclass(slots=True)
+class KalshiAdapter(BaseExchangeAdapter):
+    api_key_id: str | None = None
+    private_key_pem: bytes | None = None
+    env: str | None = None
+    timeout: int = 15
+    client_factory: KalshiClientFactory | None = None
+
+    name: str = "kalshi"
+
+    def __post_init__(self) -> None:
+        BaseExchangeAdapter.__init__(self)
+        api_key = self.api_key_id or get_api_key_id()
+        priv_key = self.private_key_pem or get_private_key_material()
+        base_url = get_base_url(self.env)
+
+        if self.client_factory is None:
+            raise ImportError(
+                "kalshi_python client factory is required. "
+                "Install with: pip install 'kalshi-python>=2'"
+            )
+
+        self._client = self.client_factory(
+            base_url=base_url,
+            api_key_id=api_key,
+            private_key_pem=priv_key,
+            timeout=self.timeout,
+        )
+        self.portfolio = ServiceProxy(getattr(self._client, "portfolio", self._client))
+        self.markets = ServiceProxy(getattr(self._client, "markets", self._client))
+        self.exchange = ServiceProxy(getattr(self._client, "exchange", self._client))
+
+    def capabilities(self) -> ExchangeCapabilities:
+        return ExchangeCapabilities(read=True, paper=True, live=True, streaming=True)
+
+    def list_markets(
+        self, *, sport: str | None = None, limit: int = 100, sports_only: bool = True
+    ) -> list[NormalizedMarket]:
+        kwargs: dict[str, Any] = {"limit": limit}
+        if sport:
+            kwargs["category"] = sport
+        elif sports_only:
+            kwargs["category"] = "sports"
+
+        raw = self._call_any(["get_markets", "list_markets"], self.markets, kwargs)
+        rows = raw.get("markets", raw if isinstance(raw, list) else [])
+        return [self._normalize_market(m) for m in rows]
+
+    def get_quote(self, market_id: str) -> NormalizedQuote:
+        raw = self._call_any(
+            ["get_market", "get_event", "market"],
+            self.markets,
+            {"market_id": market_id, "ticker": market_id},
+        )
+        market = raw.get("market", raw)
+        return NormalizedQuote(
+            market_id=str(market.get("ticker") or market.get("id") or market_id),
+            yes_bid=_to_prob(market.get("yes_bid")),
+            yes_ask=_to_prob(market.get("yes_ask")),
+            no_bid=_to_prob(market.get("no_bid")),
+            no_ask=_to_prob(market.get("no_ask")),
+            last_price=_to_prob(market.get("last_price") or market.get("yes_price")),
+            volume=_to_float(market.get("volume")),
+            metadata={"exchange": "kalshi", "raw": market},
+        )
+
+    def place_order(
+        self,
+        order: NormalizedOrderRequest,
+        *,
+        policy: TradingPolicy | None = None,
+    ) -> NormalizedOrderResult:
+        if policy is not None:
+            self._enforce_policy(order, policy)
+
+        side = "yes" if order.side.endswith("yes") else "no"
+        payload: dict[str, Any] = {
+            "market_id": order.market_id,
+            "side": side,
+            "quantity": order.quantity,
+            "type": order.order_type,
+        }
+        if order.price is not None:
+            payload["price"] = order.price
+
+        raw = self._call_any(["create_order", "place_order"], self.exchange, payload)
+        order_data = raw.get("order", raw)
+        return NormalizedOrderResult(
+            success=True,
+            status=str(order_data.get("status", "submitted")),
+            order_id=str(order_data.get("id") or order_data.get("order_id") or ""),
+            metadata={"exchange": "kalshi", "raw": raw},
+        )
+
+    def cancel_order(self, order_id: str) -> NormalizedOrderResult:
+        raw = self._call_any(["cancel_order", "delete_order"], self.exchange, {"order_id": order_id})
+        status = "cancelled" if raw is not None else "unknown"
+        return NormalizedOrderResult(
+            success=True,
+            status=status,
+            order_id=order_id,
+            metadata={"exchange": "kalshi", "raw": raw},
+        )
+
+    def get_order_status(self, order_id: str) -> NormalizedOrderResult:
+        raw = self._call_any(["get_order", "order"], self.exchange, {"order_id": order_id})
+        order_data = raw.get("order", raw)
+        return NormalizedOrderResult(
+            success=True,
+            status=str(order_data.get("status", "unknown")),
+            order_id=str(order_data.get("id") or order_data.get("order_id") or order_id),
+            metadata={"exchange": "kalshi", "raw": raw},
+        )
+
+    def get_positions(self) -> list[NormalizedPosition]:
+        raw = self._call_any(["get_positions", "positions"], self.portfolio, {})
+        rows = raw.get("positions", raw if isinstance(raw, list) else [])
+        out: list[NormalizedPosition] = []
+        for row in rows:
+            out.append(
+                NormalizedPosition(
+                    market_id=str(row.get("market_id") or row.get("ticker") or ""),
+                    side="yes" if str(row.get("side", "yes")).lower() == "yes" else "no",
+                    quantity=int(row.get("quantity") or row.get("count") or 0),
+                    entry_price=_to_prob(row.get("avg_price") or row.get("entry_price")),
+                    current_price=_to_prob(row.get("current_price")),
+                    unrealized_pnl=_to_float(row.get("unrealized_pnl")),
+                    metadata={"exchange": "kalshi", "raw": row},
+                )
+            )
+        return out
+
+    def close(self) -> None:
+        if hasattr(self._client, "close"):
+            try:
+                self._client.close()
+            except Exception:
+                pass
+
+    @staticmethod
+    def _normalize_market(raw: dict[str, Any]) -> NormalizedMarket:
+        market_id = str(raw.get("ticker") or raw.get("id") or "")
+        return NormalizedMarket(
+            market_id=market_id,
+            ticker=market_id,
+            title=str(raw.get("title") or raw.get("name") or market_id),
+            status=str(raw.get("status") or "open"),
+            yes_price=_to_prob(raw.get("yes_ask") or raw.get("yes_price")),
+            no_price=_to_prob(raw.get("no_ask") or raw.get("no_price")),
+            category=str(raw.get("category") or "sports"),
+            sport=str(raw.get("sport") or raw.get("category") or "sports"),
+            metadata={"exchange": "kalshi", "raw": raw},
+        )
+
+    @staticmethod
+    def _call_any(method_names: list[str], target: Any, kwargs: dict[str, Any]) -> Any:
+        cleaned_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        for name in method_names:
+            method = getattr(target, name, None)
+            if not callable(method):
+                continue
+            try:
+                return method(**cleaned_kwargs)
+            except TypeError:
+                # Retry with no kwargs for methods that do not accept filter args.
+                if cleaned_kwargs:
+                    try:
+                        return method()
+                    except TypeError:
+                        continue
+        raise AttributeError(f"None of methods {method_names} exist on target API")
+
+
+def _to_prob(value: Any) -> float | None:
+    if value is None:
+        return None
+    f = float(value)
+    if f > 1:
+        return f / 100.0
+    return f
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)

--- a/neural/trading/kalshi_adapter.py
+++ b/neural/trading/kalshi_adapter.py
@@ -8,6 +8,7 @@ from neural.auth.env import get_api_key_id, get_base_url, get_private_key_materi
 from neural.exchanges.base import BaseExchangeAdapter
 from neural.exchanges.types import (
     ExchangeCapabilities,
+    ExchangeName,
     NormalizedMarket,
     NormalizedOrderRequest,
     NormalizedOrderResult,
@@ -64,7 +65,7 @@ class KalshiAdapter(BaseExchangeAdapter):
     timeout: int = 15
     client_factory: KalshiClientFactory | None = None
 
-    name: str = "kalshi"
+    name: ExchangeName = "kalshi"
 
     def __post_init__(self) -> None:
         BaseExchangeAdapter.__init__(self)

--- a/neural/trading/kalshi_adapter.py
+++ b/neural/trading/kalshi_adapter.py
@@ -155,7 +155,9 @@ class KalshiAdapter(BaseExchangeAdapter):
         )
 
     def cancel_order(self, order_id: str) -> NormalizedOrderResult:
-        raw = self._call_any(["cancel_order", "delete_order"], self.exchange, {"order_id": order_id})
+        raw = self._call_any(
+            ["cancel_order", "delete_order"], self.exchange, {"order_id": order_id}
+        )
         status = "cancelled" if raw is not None else "unknown"
         return NormalizedOrderResult(
             success=True,

--- a/neural/trading/kalshi_adapter.py
+++ b/neural/trading/kalshi_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any, Protocol
@@ -223,16 +224,47 @@ class KalshiAdapter(BaseExchangeAdapter):
             method = getattr(target, name, None)
             if not callable(method):
                 continue
-            try:
+            if KalshiAdapter._can_call_with_kwargs(method, cleaned_kwargs):
                 return method(**cleaned_kwargs)
-            except TypeError:
-                # Retry with no kwargs for methods that do not accept filter args.
-                if cleaned_kwargs:
-                    try:
-                        return method()
-                    except TypeError:
-                        continue
+            if cleaned_kwargs and KalshiAdapter._can_call_without_kwargs(method):
+                return method()
         raise AttributeError(f"None of methods {method_names} exist on target API")
+
+    @staticmethod
+    def _can_call_with_kwargs(method: Any, kwargs: dict[str, Any]) -> bool:
+        if not kwargs:
+            return True
+        try:
+            sig = inspect.signature(method)
+        except (TypeError, ValueError):
+            return True
+
+        params = sig.parameters.values()
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params):
+            return True
+
+        allowed = {
+            name
+            for name, param in sig.parameters.items()
+            if param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        }
+        return set(kwargs).issubset(allowed)
+
+    @staticmethod
+    def _can_call_without_kwargs(method: Any) -> bool:
+        try:
+            sig = inspect.signature(method)
+        except (TypeError, ValueError):
+            return False
+
+        for param in sig.parameters.values():
+            if param.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            ) and param.default is inspect.Parameter.empty:
+                return False
+        return True
 
 
 def _to_prob(value: Any) -> float | None:

--- a/neural/trading/kalshi_adapter.py
+++ b/neural/trading/kalshi_adapter.py
@@ -129,8 +129,9 @@ class KalshiAdapter(BaseExchangeAdapter):
         *,
         policy: TradingPolicy | None = None,
     ) -> NormalizedOrderResult:
+        notional_to_record = 0.0
         if policy is not None:
-            self._enforce_policy(order, policy)
+            notional_to_record = self._enforce_policy(order, policy)
 
         side = "yes" if order.side.endswith("yes") else "no"
         payload: dict[str, Any] = {
@@ -143,6 +144,8 @@ class KalshiAdapter(BaseExchangeAdapter):
             payload["price"] = order.price
 
         raw = self._call_any(["create_order", "place_order"], self.exchange, payload)
+        if policy is not None:
+            self._record_daily_notional(notional_to_record)
         order_data = raw.get("order", raw)
         return NormalizedOrderResult(
             success=True,

--- a/neural/trading/kalshi_adapter.py
+++ b/neural/trading/kalshi_adapter.py
@@ -246,7 +246,8 @@ class KalshiAdapter(BaseExchangeAdapter):
         allowed = {
             name
             for name, param in sig.parameters.items()
-            if param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+            if param.kind
+            in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
         }
         return set(kwargs).issubset(allowed)
 
@@ -258,11 +259,15 @@ class KalshiAdapter(BaseExchangeAdapter):
             return False
 
         for param in sig.parameters.values():
-            if param.kind in (
-                inspect.Parameter.POSITIONAL_ONLY,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.KEYWORD_ONLY,
-            ) and param.default is inspect.Parameter.empty:
+            if (
+                param.kind
+                in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+                and param.default is inspect.Parameter.empty
+            ):
                 return False
         return True
 

--- a/tests/exchanges/test_kalshi_adapter_contract.py
+++ b/tests/exchanges/test_kalshi_adapter_contract.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from neural.exchanges.types import NormalizedOrderRequest, TradingPolicy
 from neural.trading.kalshi_adapter import KalshiAdapter
 
@@ -90,3 +92,13 @@ def test_kalshi_adapter_contract_methods() -> None:
 
     positions = adapter.get_positions()
     assert positions[0].quantity == 5
+
+
+def test_call_any_does_not_swallow_internal_type_errors() -> None:
+    class _BuggyMarkets:
+        def get_markets(self, **kwargs: Any) -> dict[str, Any]:
+            del kwargs
+            raise TypeError("internal bug")
+
+    with pytest.raises(TypeError, match="internal bug"):
+        KalshiAdapter._call_any(["get_markets"], _BuggyMarkets(), {"limit": 10})

--- a/tests/exchanges/test_kalshi_adapter_contract.py
+++ b/tests/exchanges/test_kalshi_adapter_contract.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+from neural.exchanges.types import NormalizedOrderRequest, TradingPolicy
+from neural.trading.kalshi_adapter import KalshiAdapter
+
+
+class _Markets:
+    def get_markets(self, **kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        return {
+            "markets": [
+                {
+                    "ticker": "KX-1",
+                    "title": "Will Team A win?",
+                    "status": "open",
+                    "yes_ask": 62,
+                    "no_ask": 38,
+                    "category": "sports",
+                }
+            ]
+        }
+
+    def get_market(self, **kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        return {"market": {"ticker": "KX-1", "yes_bid": 61, "yes_ask": 63}}
+
+
+class _Exchange:
+    def create_order(self, **kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        return {"order": {"id": "ord-k-1", "status": "submitted"}}
+
+    def cancel_order(self, **kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        return {"status": "cancelled"}
+
+    def get_order(self, **kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        return {"order": {"id": "ord-k-1", "status": "filled"}}
+
+
+class _Portfolio:
+    def get_positions(self) -> dict[str, Any]:
+        return {
+            "positions": [
+                {
+                    "market_id": "KX-1",
+                    "side": "yes",
+                    "quantity": 5,
+                    "entry_price": 0.5,
+                }
+            ]
+        }
+
+
+class _Client:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.markets = _Markets()
+        self.exchange = _Exchange()
+        self.portfolio = _Portfolio()
+
+    def close(self) -> None:
+        return None
+
+
+def test_kalshi_adapter_contract_methods() -> None:
+    adapter = KalshiAdapter(
+        api_key_id="abc",
+        private_key_pem=b"pem",
+        client_factory=lambda **kwargs: _Client(**kwargs),
+    )
+
+    assert adapter.capabilities().as_dict()["read"] is True
+
+    markets = adapter.list_markets()
+    assert markets[0].market_id == "KX-1"
+
+    quote = adapter.get_quote("KX-1")
+    assert quote.yes_ask == 0.63
+
+    order = NormalizedOrderRequest(market_id="KX-1", side="buy_yes", quantity=2, price=0.61)
+    result = adapter.place_order(order, policy=TradingPolicy(live_enabled=True))
+    assert result.order_id == "ord-k-1"
+
+    status = adapter.get_order_status("ord-k-1")
+    assert status.status == "filled"
+
+    positions = adapter.get_positions()
+    assert positions[0].quantity == 5

--- a/tests/exchanges/test_policy_guards.py
+++ b/tests/exchanges/test_policy_guards.py
@@ -61,23 +61,26 @@ def test_daily_notional_resets_after_day_rollover() -> None:
     policy = TradingPolicy(live_enabled=True, max_daily_notional=5.0)
 
     first = NormalizedOrderRequest(market_id="MKT-1", side="buy_yes", quantity=4, price=1.0)
-    adapter._enforce_policy(first, policy)
+    notional = adapter._enforce_policy(first, policy)
+    adapter._record_daily_notional(notional)
 
     adapter._daily_notional_date = adapter._daily_notional_date - timedelta(days=1)
     second = NormalizedOrderRequest(market_id="MKT-2", side="buy_yes", quantity=4, price=1.0)
 
     # Should pass after rollover rather than failing against yesterday's usage.
-    adapter._enforce_policy(second, policy)
+    notional = adapter._enforce_policy(second, policy)
+    adapter._record_daily_notional(notional)
 
 
 def test_daily_notional_still_enforced_within_same_day() -> None:
     adapter = _PolicyAdapter()
     policy = TradingPolicy(live_enabled=True, max_daily_notional=5.0)
 
-    adapter._enforce_policy(
+    first_notional = adapter._enforce_policy(
         NormalizedOrderRequest(market_id="MKT-1", side="buy_yes", quantity=4, price=1.0),
         policy,
     )
+    adapter._record_daily_notional(first_notional)
     with pytest.raises(ValueError):
         adapter._enforce_policy(
             NormalizedOrderRequest(market_id="MKT-2", side="buy_yes", quantity=2, price=1.0),

--- a/tests/exchanges/test_policy_guards.py
+++ b/tests/exchanges/test_policy_guards.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from neural.exchanges.base import BaseExchangeAdapter
+from neural.exchanges.types import (
+    ExchangeCapabilities,
+    NormalizedMarket,
+    NormalizedOrderRequest,
+    NormalizedOrderResult,
+    NormalizedPosition,
+    NormalizedQuote,
+    TradingPolicy,
+)
+
+
+class _PolicyAdapter(BaseExchangeAdapter):
+    name = "kalshi"
+
+    def capabilities(self) -> ExchangeCapabilities:
+        return ExchangeCapabilities(read=True, paper=True, live=True, streaming=True)
+
+    def list_markets(
+        self, *, sport: str | None = None, limit: int = 100, sports_only: bool = True
+    ) -> list[NormalizedMarket]:
+        del sport, limit, sports_only
+        return []
+
+    def get_quote(self, market_id: str) -> NormalizedQuote:
+        del market_id
+        raise NotImplementedError
+
+    def place_order(
+        self,
+        order: NormalizedOrderRequest,
+        *,
+        policy: TradingPolicy | None = None,
+    ) -> NormalizedOrderResult:
+        del order, policy
+        raise NotImplementedError
+
+    def cancel_order(self, order_id: str) -> NormalizedOrderResult:
+        del order_id
+        raise NotImplementedError
+
+    def get_order_status(self, order_id: str) -> NormalizedOrderResult:
+        del order_id
+        raise NotImplementedError
+
+    def get_positions(self) -> list[NormalizedPosition]:
+        return []
+
+    def close(self) -> None:
+        return None
+
+
+def test_daily_notional_resets_after_day_rollover() -> None:
+    adapter = _PolicyAdapter()
+    policy = TradingPolicy(live_enabled=True, max_daily_notional=5.0)
+
+    first = NormalizedOrderRequest(market_id="MKT-1", side="buy_yes", quantity=4, price=1.0)
+    adapter._enforce_policy(first, policy)
+
+    adapter._daily_notional_date = adapter._daily_notional_date - timedelta(days=1)
+    second = NormalizedOrderRequest(market_id="MKT-2", side="buy_yes", quantity=4, price=1.0)
+
+    # Should pass after rollover rather than failing against yesterday's usage.
+    adapter._enforce_policy(second, policy)
+
+
+def test_daily_notional_still_enforced_within_same_day() -> None:
+    adapter = _PolicyAdapter()
+    policy = TradingPolicy(live_enabled=True, max_daily_notional=5.0)
+
+    adapter._enforce_policy(
+        NormalizedOrderRequest(market_id="MKT-1", side="buy_yes", quantity=4, price=1.0),
+        policy,
+    )
+    with pytest.raises(ValueError):
+        adapter._enforce_policy(
+            NormalizedOrderRequest(market_id="MKT-2", side="buy_yes", quantity=2, price=1.0),
+            policy,
+        )

--- a/tests/trading/test_trading_client_paper.py
+++ b/tests/trading/test_trading_client_paper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 from typing import Any
 
@@ -23,6 +24,17 @@ class _FakePaperClient:
         self.close_calls.append({"market_id": market_id, "side": side, "quantity": quantity})
         return {"success": True, "closed_quantity": quantity}
 
+    async def place_order(
+        self,
+        market_id: str,
+        side: str,
+        quantity: int,
+        order_type: str = "market",
+        price: float | None = None,
+    ) -> dict[str, Any]:
+        del order_type, price
+        return {"success": True, "market_id": market_id, "side": side, "quantity": quantity}
+
 
 def _fake_creds(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KALSHI_API_KEY_ID", "abc123")
@@ -40,3 +52,16 @@ def test_paper_sell_uses_requested_quantity(monkeypatch: pytest.MonkeyPatch) -> 
     assert out["success"] is True
     assert out["closed_quantity"] == 3
     assert fake_paper.close_calls == [{"market_id": "MKT-1", "side": "yes", "quantity": 3}]
+
+
+def test_paper_buy_works_inside_running_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_creds(monkeypatch)
+    client = TradingClient(client_factory=lambda **_: _DummyClient(), paper_trading=True)
+    client._paper_client = _FakePaperClient()
+
+    async def _call_sync_api() -> dict[str, Any]:
+        return client.place_order(market_id="MKT-2", side="buy_yes", quantity=2, paper=True)
+
+    out = asyncio.run(_call_sync_api())
+    assert out["success"] is True
+    assert out["quantity"] == 2

--- a/tests/trading/test_trading_client_paper.py
+++ b/tests/trading/test_trading_client_paper.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+import neural.trading.client as trading_client_module
 from neural.trading.client import TradingClient
 
 
@@ -67,3 +68,24 @@ def test_paper_buy_works_inside_running_event_loop(monkeypatch: pytest.MonkeyPat
     out = asyncio.run(_call_sync_api())
     assert out["success"] is True
     assert out["quantity"] == 2
+
+
+def test_run_coro_sync_uses_non_daemon_thread_inside_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    real_thread_cls = trading_client_module.threading.Thread
+
+    class _RecordingThread(real_thread_cls):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            seen["daemon"] = kwargs.get("daemon")
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(trading_client_module.threading, "Thread", _RecordingThread)
+
+    async def _call_sync_bridge() -> int:
+        return trading_client_module._run_coro_sync(asyncio.sleep(0, result=7))
+
+    assert asyncio.run(_call_sync_bridge()) == 7
+    assert seen["daemon"] in (None, False)

--- a/tests/trading/test_trading_client_paper.py
+++ b/tests/trading/test_trading_client_paper.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import pytest
+
+from neural.trading.client import TradingClient
+
+
+class _DummyClient:
+    def __init__(self, **kwargs: Any) -> None:  # noqa: ARG002
+        self.portfolio = object()
+        self.markets = object()
+        self.exchange = object()
+
+
+class _FakePaperClient:
+    def __init__(self) -> None:
+        self.close_calls: list[dict[str, Any]] = []
+
+    def close_position(self, market_id: str, side: str, quantity: int | None = None) -> dict[str, Any]:
+        self.close_calls.append({"market_id": market_id, "side": side, "quantity": quantity})
+        return {"success": True, "closed_quantity": quantity}
+
+
+def _fake_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KALSHI_API_KEY_ID", "abc123")
+    monkeypatch.setenv("KALSHI_PRIVATE_KEY_BASE64", base64.b64encode(b"KEY").decode())
+
+
+def test_paper_sell_uses_requested_quantity(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_creds(monkeypatch)
+    client = TradingClient(client_factory=lambda **_: _DummyClient(), paper_trading=True)
+    fake_paper = _FakePaperClient()
+    client._paper_client = fake_paper
+
+    out = client.place_order(market_id="MKT-1", side="sell_yes", quantity=3, paper=True)
+
+    assert out["success"] is True
+    assert out["closed_quantity"] == 3
+    assert fake_paper.close_calls == [{"market_id": "MKT-1", "side": "yes", "quantity": 3}]

--- a/tests/trading/test_trading_client_paper.py
+++ b/tests/trading/test_trading_client_paper.py
@@ -20,7 +20,9 @@ class _FakePaperClient:
     def __init__(self) -> None:
         self.close_calls: list[dict[str, Any]] = []
 
-    def close_position(self, market_id: str, side: str, quantity: int | None = None) -> dict[str, Any]:
+    def close_position(
+        self, market_id: str, side: str, quantity: int | None = None
+    ) -> dict[str, Any]:
         self.close_calls.append({"market_id": market_id, "side": side, "quantity": quantity})
         return {"success": True, "closed_quantity": quantity}
 

--- a/tests/trading/test_trading_client_serialize.py
+++ b/tests/trading/test_trading_client_serialize.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 
+import neural.trading.client as trading_client_module
 from neural.trading.client import TradingClient
 
 
@@ -58,3 +59,25 @@ def test_non_callable_attribute_passthrough(monkeypatch: pytest.MonkeyPatch) -> 
     client = TradingClient(client_factory=lambda **_: DummyClient())
 
     assert client.exchange.answer == 42
+
+
+def test_compat_wrappers_do_not_reserialize_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _CompatClient:
+        def list_markets(self, **kwargs: Any) -> list[dict[str, Any]]:
+            del kwargs
+            return [{"market_id": "KX-1"}]
+
+        def get_positions(self) -> list[dict[str, Any]]:
+            return [{"market_id": "KX-1", "quantity": 2}]
+
+    def _unexpected_serialize(_: Any) -> Any:
+        raise AssertionError("compat wrappers should not call serialize_value")
+
+    monkeypatch.setattr(trading_client_module, "serialize_value", _unexpected_serialize)
+    compat_client = _CompatClient()
+
+    markets = trading_client_module._CompatMarkets(compat_client).get_markets()
+    positions = trading_client_module._CompatPortfolio(compat_client).get_positions()
+
+    assert markets == {"markets": [{"market_id": "KX-1"}]}
+    assert positions == {"positions": [{"market_id": "KX-1", "quantity": 2}]}


### PR DESCRIPTION
## Summary
- add exchange abstraction core in neural/exchanges with normalized models and adapter contract
- refactor TradingClient to route Kalshi through an exchange adapter while preserving default behavior
- add Kalshi adapter contract test coverage

## Validation
- ruff check neural/exchanges neural/trading/client.py neural/trading/kalshi_adapter.py neural/trading/__init__.py neural/__init__.py tests/exchanges/test_kalshi_adapter_contract.py
- pytest -q tests/trading/test_trading_client_unit.py tests/trading/test_trading_client_serialize.py tests/trading/test_trading_client_errors.py tests/exchanges/test_kalshi_adapter_contract.py tests/test_public_api.py

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a foundational exchange abstraction layer (`neural/exchanges`) that decouples trading logic from Kalshi-specific implementation, enabling future multi-exchange support. The refactor maintains full backward compatibility with existing `TradingClient` usage while routing Kalshi operations through a new adapter pattern.

**Key architectural changes:**
- Created `ExchangeAdapter` abstract base class with normalized models (`NormalizedMarket`, `NormalizedOrderRequest`, `NormalizedPosition`, etc.)
- Implemented `KalshiAdapter` that translates between normalized types and the kalshi-python SDK, handling multiple SDK method naming conventions via signature inspection
- Added `BaseExchangeAdapter` with built-in policy enforcement for live trading (market allowlists, per-order limits, daily notional caps with automatic rollover)
- Refactored `TradingClient` to delegate to adapters via a registry pattern while preserving existing API surface through compatibility wrappers

**Improvements from previous feedback (all addressed):**
- Daily notional now increments only after successful order placement (not before)
- `_call_any` uses signature inspection instead of catching `TypeError`, preventing internal bugs from being swallowed
- Removed double serialization in compat wrappers (`_CompatMarkets`, `_CompatPortfolio`)
- Sell orders now correctly pass quantity to `close_position`
- Event loop helper uses non-daemon threads to prevent premature termination
- `name` field type corrected to `ExchangeName` instead of `str`

**Test coverage:**
- Contract tests validate all adapter methods and error handling
- Policy guard tests verify daily notional rollover and enforcement
- Paper trading tests confirm sell order quantity and thread behavior
- Serialization tests prevent regression of double-serialization bug

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - all previous feedback has been addressed with comprehensive test coverage
- The PR introduces a well-architected exchange abstraction layer with clean separation of concerns. All issues from previous review threads have been addressed: daily notional tracking fixed, TypeError handling improved, double serialization removed, sell order quantity passed correctly, daemon thread issue resolved, and name field type corrected. The implementation includes comprehensive test coverage validating both the new functionality and the fixes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| neural/exchanges/types.py | introduced normalized data models for exchange-agnostic trading (markets, quotes, orders, positions) and policy types - clean dataclass definitions with no issues |
| neural/exchanges/base.py | added abstract `ExchangeAdapter` contract and `BaseExchangeAdapter` with policy enforcement - daily notional tracking correctly resets and records post-order-success |
| neural/trading/kalshi_adapter.py | implements Kalshi exchange adapter with SDK compatibility layer - uses signature inspection to handle method variations, correctly records notional post-success, avoids swallowing internal errors |
| neural/trading/client.py | refactored to route through exchange adapters while preserving backward compatibility - fixed double serialization, daemon thread, and sell order quantity issues from previous feedback |
| tests/exchanges/test_kalshi_adapter_contract.py | comprehensive contract tests for Kalshi adapter covering all core methods and internal error handling |
| tests/exchanges/test_policy_guards.py | tests for daily notional policy enforcement including rollover behavior - validates fix for previous feedback |

</details>



<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class ExchangeAdapter {
        <<abstract>>
        +name: ExchangeName
        +capabilities()* ExchangeCapabilities
        +list_markets()* list~NormalizedMarket~
        +get_quote()* NormalizedQuote
        +place_order()* NormalizedOrderResult
        +get_positions()* list~NormalizedPosition~
        +close()*
    }
    
    class BaseExchangeAdapter {
        <<abstract>>
        -_daily_notional_used: float
        -_daily_notional_date: date
        #_enforce_policy() float
        #_record_daily_notional()
        #_rollover_daily_notional_if_needed()
    }
    
    class KalshiAdapter {
        +name: "kalshi"
        -_client: KalshiClient
        +portfolio: ServiceProxy
        +markets: ServiceProxy
        +exchange: ServiceProxy
        +capabilities() ExchangeCapabilities
        +list_markets() list~NormalizedMarket~
        +place_order() NormalizedOrderResult
        -_call_any() Any
        -_can_call_with_kwargs() bool
    }
    
    class TradingClient {
        +exchange_name: ExchangeName
        +paper_trading: bool
        +trading_policy: TradingPolicy
        -_adapter: ExchangeAdapter
        +list_markets() list~dict~
        +place_order() dict
        +get_positions() list~dict~
    }
    
    class ExchangeRegistry {
        -_factories: dict
        +register(name, factory)
        +create(name, kwargs) ExchangeAdapter
        +names() list~str~
    }
    
    ExchangeAdapter <|-- BaseExchangeAdapter
    BaseExchangeAdapter <|-- KalshiAdapter
    TradingClient --> ExchangeAdapter : uses via registry
    TradingClient --> ExchangeRegistry : creates adapters
    ExchangeRegistry --> KalshiAdapter : instantiates
```

<sub>Last reviewed commit: d686398</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->