### PR TITLE
NRCL-28 Prepare neural-sdk 0.4.2 contact hotfix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.4.2
 commit = True
 tag = True
 tag_name = v{new_version}
@@ -9,6 +9,6 @@ message = Bump version: {current_version} → {new_version}
 search = version = "{current_version}"
 replace = version = "{new_version}"
 
-[bumpversion:file:neural/__init__.py]
+[bumpversion:file:neural/_version.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,17 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Classify release tag
+        id: release
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python scripts/validate_release.py classify-tag "${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate public contact surfaces
+        run: |
+          python scripts/validate_release.py validate-source .
+
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
@@ -25,6 +36,11 @@ jobs:
       - name: Build package
         run: |
           python -m build --no-isolation
+
+      - name: Validate release artifacts
+        run: |
+          twine check dist/*
+          python scripts/validate_release.py validate-artifacts dist/*
 
       - name: Verify source distribution installs cleanly
         run: |
@@ -36,47 +52,17 @@ jobs:
           /tmp/neural-publish-sdist-venv/bin/python "${GITHUB_WORKSPACE}/scripts/package_smoke.py"
 
       - name: Publish to PyPI
+        if: steps.release.outputs.channel == 'pypi'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          twine check dist/*
           twine upload --non-interactive --skip-existing dist/*
 
-  publish-testpypi:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install build tools
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine wheel "setuptools>=77"
-
-      - name: Build package
-        run: |
-          python -m build --no-isolation
-
-      - name: Verify source distribution installs cleanly
-        run: |
-          python -m venv /tmp/neural-testpypi-sdist-venv
-          /tmp/neural-testpypi-sdist-venv/bin/python -m pip install --upgrade pip
-          /tmp/neural-testpypi-sdist-venv/bin/python -m pip install "setuptools>=77" wheel
-          /tmp/neural-testpypi-sdist-venv/bin/python -m pip install --no-build-isolation dist/*.tar.gz
-          cd /tmp
-          /tmp/neural-testpypi-sdist-venv/bin/python "${GITHUB_WORKSPACE}/scripts/package_smoke.py"
-
       - name: Publish to TestPyPI
+        if: steps.release.outputs.channel == 'testpypi'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
         run: |
-          twine check dist/*
           twine upload --repository testpypi --non-interactive --skip-existing dist/*

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Validate public contact surfaces
+        run: |
+          python scripts/validate_release.py validate-source .
+
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
@@ -31,6 +35,7 @@ jobs:
       - name: Check package metadata
         run: |
           twine check dist/*
+          python scripts/validate_release.py validate-artifacts dist/*
 
       - name: Validate wheel install path
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-23
+
+### Security
+- Replaced public contact addresses on domains not controlled by the maintainers with the accountable maintainer address.
+- Removed the uncontrolled contributor-domain address from package author and maintainer metadata.
+
 ## [0.4.1] - 2026-04-12
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,7 +27,7 @@ Community leaders are responsible for clarifying and enforcing our standards of 
 This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
 
 ## Enforcement
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at contributors@neural-sdk.dev. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at hudson@intelip.co. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This document provides guidelines and instructions for contributing to Neural SD
 
 ## Code of Conduct
 
-This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to contributors@neural-sdk.dev.
+This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to hudson@intelip.co.
 
 ## Getting Started
 
@@ -430,6 +430,6 @@ Contributors are recognized in:
 
 - **Documentation**: https://neural-sdk.mintlify.app
 - **Discussions**: https://github.com/IntelIP/Neural/discussions
-- **Email**: contributors@neural-sdk.dev
+- **Email**: hudson@intelip.co
 
 Thank you for contributing to Neural SDK!

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,6 @@ include CHANGELOG.md
 recursive-include docs *
 recursive-include neural *.py
 include neural/py.typed
+exclude tests/test_contact_security.py
+exclude tests/test_release_validation.py
 global-exclude *.py[cod] __pycache__ *.so *.dylib

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -19,7 +19,7 @@
   "topbarLinks": [
     {
       "name": "Support",
-      "url": "mailto:support@neural-sdk.com"
+      "url": "mailto:hudson@intelip.co"
     }
   ],
   "topbarCtaButton": {

--- a/docs/openapi/authentication-schemes.yaml
+++ b/docs/openapi/authentication-schemes.yaml
@@ -30,7 +30,7 @@ info:
   version: 1.0.0
   contact:
     name: Neural SDK Support
-    email: support@neural-sdk.com
+    email: hudson@intelip.co
     url: https://github.com/IntelIP/Neural
   license:
     name: MIT

--- a/docs/openapi/data-collection-apis.yaml
+++ b/docs/openapi/data-collection-apis.yaml
@@ -27,7 +27,7 @@ info:
   version: 1.0.0
   contact:
     name: Neural SDK Support
-    email: support@neural-sdk.com
+    email: hudson@intelip.co
     url: https://github.com/IntelIP/Neural
   license:
     name: MIT

--- a/docs/openapi/data-models.yaml
+++ b/docs/openapi/data-models.yaml
@@ -25,7 +25,7 @@ info:
   version: 1.0.0
   contact:
     name: Neural SDK Support
-    email: support@neural-sdk.com
+    email: hudson@intelip.co
     url: https://github.com/IntelIP/Neural
   license:
     name: MIT

--- a/docs/openapi/fix-protocol.yaml
+++ b/docs/openapi/fix-protocol.yaml
@@ -33,7 +33,7 @@ info:
   version: 5.0.2
   contact:
     name: Neural SDK Support
-    email: support@neural-sdk.com
+    email: hudson@intelip.co
     url: https://github.com/IntelIP/Neural
   license:
     name: MIT

--- a/docs/openapi/kalshi-trading-api.yaml
+++ b/docs/openapi/kalshi-trading-api.yaml
@@ -18,7 +18,7 @@ info:
   version: 2.0.0
   contact:
     name: Neural SDK Support
-    email: support@neural-sdk.com
+    email: hudson@intelip.co
     url: https://github.com/IntelIP/Neural
   license:
     name: MIT

--- a/docs/openapi/websocket-api.yaml
+++ b/docs/openapi/websocket-api.yaml
@@ -26,7 +26,7 @@ info:
   version: 2.0.0
   contact:
     name: Neural SDK Support
-    email: support@neural-sdk.com
+    email: hudson@intelip.co
     url: https://github.com/IntelIP/Neural
 
 servers:

--- a/neural/_version.py
+++ b/neural/_version.py
@@ -1,3 +1,3 @@
 """Single-source package version metadata."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neural-sdk"
-version = "0.4.1"
+version = "0.4.2"
 description = "Professional-grade SDK for algorithmic trading on prediction markets (Beta - Core features stable, advanced modules experimental)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -19,11 +19,10 @@ keywords = [
 ]
 authors = [
     { name = "Hudson Aikins", email = "hudson@intelip.co" },
-    { name = "Neural Contributors", email = "contributors@neural-sdk.dev" }
+    { name = "Neural Contributors" }
 ]
 maintainers = [
-    { name = "Advanced Intellectual Labs LLC", email = "hudson@intelip.co" },
-    { name = "Neural Contributors", email = "contributors@neural-sdk.dev" }
+    { name = "Advanced Intellectual Labs LLC", email = "hudson@intelip.co" }
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/scripts/generate_openapi_specs.py
+++ b/scripts/generate_openapi_specs.py
@@ -19,7 +19,7 @@ class OpenAPIGenerator:
                 "title": "Neural SDK API",
                 "version": "0.3.0",
                 "description": "REST API for Neural SDK trading and data collection functionality",
-                "contact": {"name": "Neural SDK Team", "email": "support@neural-sdk.com"},
+                "contact": {"name": "Neural SDK Team", "email": "hudson@intelip.co"},
                 "license": {
                     "name": "MIT",
                     "url": "https://github.com/IntelIP/Neural/blob/main/LICENSE",

--- a/scripts/package_smoke.py
+++ b/scripts/package_smoke.py
@@ -46,7 +46,12 @@ def _assert_optional_dependency_contract() -> None:
             KalshiWebSocketClient,
         )
 
-        for symbol in (WebSocketSource, FIXConnectionConfig, KalshiFIXClient, KalshiWebSocketClient):
+        for symbol in (
+            WebSocketSource,
+            FIXConnectionConfig,
+            KalshiFIXClient,
+            KalshiWebSocketClient,
+        ):
             try:
                 symbol()
             except ImportError as exc:
@@ -107,7 +112,18 @@ def _assert_import_surface() -> None:
         TradingClient,
     )
 
-    assert AuthClient and Strategy and DataSource and TradingClient
+    assert all(
+        (
+            AuthClient,
+            Strategy,
+            DataSource,
+            WebSocketSource,
+            TradingClient,
+            FIXConnectionConfig,
+            KalshiFIXClient,
+            KalshiWebSocketClient,
+        )
+    )
 
     _assert_optional_dependency_contract()
 

--- a/scripts/package_smoke.py
+++ b/scripts/package_smoke.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import subprocess
 import sys
+from importlib.metadata import version as distribution_version
 from pathlib import Path
 
 
@@ -62,7 +63,7 @@ def _assert_optional_dependency_contract() -> None:
         builtins.__import__ = original_import
 
 
-def _assert_clean_cli() -> None:
+def _assert_clean_cli(expected_version: str) -> None:
     cli_path = Path(sys.executable).with_name("neural")
 
     version = subprocess.run(
@@ -71,7 +72,7 @@ def _assert_clean_cli() -> None:
         text=True,
         check=True,
     )
-    assert version.stdout.strip() == "0.4.2"
+    assert version.stdout.strip() == expected_version
     assert version.stderr == ""
 
     doctor = subprocess.run(
@@ -82,19 +83,19 @@ def _assert_clean_cli() -> None:
     )
     assert doctor.stderr == ""
     payload = json.loads(doctor.stdout)
-    assert payload["version"] == "0.4.2"
+    assert payload["version"] == expected_version
     assert "credentials" in payload
     assert "optional_dependencies" in payload
 
 
-def _assert_import_surface() -> None:
+def _assert_import_surface(expected_version: str) -> None:
     import neural
     import neural.auth as auth
     import neural.cli
     import neural.data_collection as data_collection
     import neural.trading as trading
 
-    assert neural.__version__ == "0.4.2"
+    assert neural.__version__ == expected_version
     assert neural.cli.main
     assert auth.__all__ and data_collection.__all__ and trading.__all__
     assert "site-packages" in neural.__file__
@@ -129,8 +130,9 @@ def _assert_import_surface() -> None:
 
 
 def main() -> int:
-    _assert_import_surface()
-    _assert_clean_cli()
+    expected_version = distribution_version("neural-sdk")
+    _assert_import_surface(expected_version)
+    _assert_clean_cli(expected_version)
     return 0
 
 

--- a/scripts/package_smoke.py
+++ b/scripts/package_smoke.py
@@ -66,7 +66,7 @@ def _assert_clean_cli() -> None:
         text=True,
         check=True,
     )
-    assert version.stdout.strip() == "0.4.1"
+    assert version.stdout.strip() == "0.4.2"
     assert version.stderr == ""
 
     doctor = subprocess.run(
@@ -77,7 +77,7 @@ def _assert_clean_cli() -> None:
     )
     assert doctor.stderr == ""
     payload = json.loads(doctor.stdout)
-    assert payload["version"] == "0.4.1"
+    assert payload["version"] == "0.4.2"
     assert "credentials" in payload
     assert "optional_dependencies" in payload
 
@@ -89,7 +89,7 @@ def _assert_import_surface() -> None:
     import neural.data_collection as data_collection
     import neural.trading as trading
 
-    assert neural.__version__ == "0.4.1"
+    assert neural.__version__ == "0.4.2"
     assert neural.cli.main
     assert auth.__all__ and data_collection.__all__ and trading.__all__
     assert "site-packages" in neural.__file__

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -16,14 +16,16 @@ except ModuleNotFoundError:  # pragma: no cover - exercised by Python 3.10 CI
     import tomli as tomllib
 
 _VERSION_CORE = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+_VERSION_NUMBER = r"(?:0|[1-9]\d*)"
 _STABLE_VERSION = re.compile(rf"^{_VERSION_CORE}$")
 _TEST_VERSION = re.compile(
-    rf"^{_VERSION_CORE}(?:(?:a|b|rc)\d+|(?:\.?dev)\d+" rf"|-(?:alpha|beta|rc|dev)\.(?:0|[1-9]\d*))$"
+    rf"^{_VERSION_CORE}(?:(?:a|b|rc){_VERSION_NUMBER}|(?:\.?dev){_VERSION_NUMBER}"
+    rf"|-(?:alpha|beta|rc|dev)\.{_VERSION_NUMBER})$"
 )
 _VERSION_ALIAS = re.compile(
-    rf"^(?P<core>{_VERSION_CORE})-(?P<label>alpha|beta|rc|dev)\.(?P<number>\d+)$"
+    rf"^(?P<core>{_VERSION_CORE})-(?P<label>alpha|beta|rc|dev)" rf"\.(?P<number>{_VERSION_NUMBER})$"
 )
-_DEV_WITHOUT_DOT = re.compile(rf"^(?P<core>{_VERSION_CORE})dev(?P<number>\d+)$")
+_DEV_WITHOUT_DOT = re.compile(rf"^(?P<core>{_VERSION_CORE})dev(?P<number>{_VERSION_NUMBER})$")
 
 _BLOCKED_DOMAINS = tuple(f"neural-sdk.{suffix}".encode("ascii") for suffix in ("dev", "com"))
 _EXPECTED_METADATA = {

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import tarfile
+import zipfile
+from email.parser import BytesParser
+from email.policy import default
+from pathlib import Path
+from typing import BinaryIO
+
+import tomllib
+
+_VERSION_CORE = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+_SEMVER_IDENTIFIER = r"(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
+_STABLE_VERSION = re.compile(rf"^{_VERSION_CORE}$")
+_TEST_VERSION = re.compile(
+    rf"^{_VERSION_CORE}(?:(?:a|b|rc|dev)\d+|\.dev\d+"
+    rf"|-{_SEMVER_IDENTIFIER}(?:\.{_SEMVER_IDENTIFIER})*)$"
+)
+
+_BLOCKED_DOMAINS = tuple(f"neural-sdk.{suffix}".encode("ascii") for suffix in ("dev", "com"))
+_EXPECTED_METADATA = {
+    "Author-email": "Hudson Aikins <hudson@intelip.co>",
+    "Maintainer-email": "Advanced Intellectual Labs LLC <hudson@intelip.co>",
+}
+_IGNORED_SOURCE_PARTS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "tests",
+    "venv",
+}
+
+
+class ReleaseValidationError(ValueError):
+    """Release input failed a deterministic safety check."""
+
+
+def project_version(project_file: Path) -> str:
+    """Read the package version used to build release artifacts."""
+    try:
+        with project_file.open("rb") as stream:
+            version = tomllib.load(stream)["project"]["version"]
+    except (OSError, KeyError, tomllib.TOMLDecodeError) as exc:
+        raise ReleaseValidationError(
+            f"cannot read project version from {project_file}: {exc}"
+        ) from exc
+    if not isinstance(version, str) or not version:
+        raise ReleaseValidationError(f"invalid project version in {project_file}")
+    return version
+
+
+def classify_tag(tag: str, expected_version: str) -> str:
+    """Return the only package index allowed for a release tag."""
+    if tag != f"v{expected_version}":
+        raise ReleaseValidationError(
+            f"release tag {tag!r} does not match project version {expected_version!r}"
+        )
+    if _STABLE_VERSION.fullmatch(expected_version):
+        return "pypi"
+    if _TEST_VERSION.fullmatch(expected_version):
+        return "testpypi"
+    raise ReleaseValidationError(f"invalid project release version: {expected_version!r}")
+
+
+def _blocked_domains_in_stream(stream: BinaryIO) -> set[str]:
+    found: set[str] = set()
+    overlap = max(map(len, _BLOCKED_DOMAINS)) - 1
+    tail = b""
+
+    while chunk := stream.read(64 * 1024):
+        normalized = (tail + chunk).lower()
+        found.update(domain.decode("ascii") for domain in _BLOCKED_DOMAINS if domain in normalized)
+        tail = normalized[-overlap:]
+
+    return found
+
+
+def _source_files(root: Path):
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if any(part in _IGNORED_SOURCE_PARTS for part in relative.parts):
+            continue
+        yield relative, path
+
+
+def validate_source(root: Path) -> None:
+    """Reject uncontrolled contact domains from public source surfaces."""
+    violations = []
+    for relative, path in _source_files(root):
+        with path.open("rb") as stream:
+            domains = _blocked_domains_in_stream(stream)
+        violations.extend(f"{relative}: {domain}" for domain in sorted(domains))
+
+    if violations:
+        raise ReleaseValidationError(
+            "uncontrolled contact domains in source: " + ", ".join(violations)
+        )
+
+
+def _validate_wheel(path: Path) -> list[str]:
+    violations = []
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for member in archive.infolist():
+                if member.is_dir():
+                    continue
+                with archive.open(member) as stream:
+                    domains = _blocked_domains_in_stream(stream)
+                violations.extend(
+                    f"{path.name}:{member.filename}: {domain}" for domain in sorted(domains)
+                )
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ReleaseValidationError(f"invalid wheel {path}: {exc}") from exc
+    return violations
+
+
+def _validate_sdist(path: Path) -> list[str]:
+    violations = []
+    try:
+        with tarfile.open(path, mode="r:*") as archive:
+            for member in archive:
+                if not member.isfile():
+                    continue
+                stream = archive.extractfile(member)
+                if stream is None:
+                    continue
+                with stream:
+                    domains = _blocked_domains_in_stream(stream)
+                violations.extend(
+                    f"{path.name}:{member.name}: {domain}" for domain in sorted(domains)
+                )
+    except (OSError, tarfile.TarError) as exc:
+        raise ReleaseValidationError(f"invalid sdist {path}: {exc}") from exc
+    return violations
+
+
+def _wheel_metadata(path: Path) -> bytes:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = [
+                member.filename
+                for member in archive.infolist()
+                if not member.is_dir() and member.filename.endswith(".dist-info/METADATA")
+            ]
+            if len(names) != 1:
+                raise ReleaseValidationError(
+                    f"expected one wheel METADATA file in {path}; found {len(names)}"
+                )
+            return archive.read(names[0])
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ReleaseValidationError(f"invalid wheel {path}: {exc}") from exc
+
+
+def _sdist_metadata(path: Path) -> bytes:
+    try:
+        with tarfile.open(path, mode="r:*") as archive:
+            members = [
+                member
+                for member in archive
+                if member.isfile()
+                and member.name.endswith("/PKG-INFO")
+                and member.name.count("/") == 1
+            ]
+            if len(members) != 1:
+                raise ReleaseValidationError(
+                    f"expected one top-level sdist PKG-INFO file in {path}; found {len(members)}"
+                )
+            stream = archive.extractfile(members[0])
+            if stream is None:
+                raise ReleaseValidationError(f"cannot read sdist metadata from {path}")
+            with stream:
+                return stream.read()
+    except (OSError, tarfile.TarError) as exc:
+        raise ReleaseValidationError(f"invalid sdist {path}: {exc}") from exc
+
+
+def _validate_core_metadata(path: Path, content: bytes, expected_version: str) -> None:
+    metadata = BytesParser(policy=default).parsebytes(content)
+    expected = {"Version": expected_version, **_EXPECTED_METADATA}
+    mismatches = [
+        f"{header}: expected {value!r}, found {metadata.get(header)!r}"
+        for header, value in expected.items()
+        if metadata.get(header) != value
+    ]
+    if mismatches:
+        raise ReleaseValidationError(
+            f"invalid core metadata in {path.name}: " + "; ".join(mismatches)
+        )
+
+
+def validate_artifacts(paths: list[Path], expected_version: str) -> None:
+    """Require one wheel and one sdist, both free of uncontrolled contacts."""
+    violations = []
+    wheels = []
+    sdists = []
+
+    for path in paths:
+        if path.suffix == ".whl":
+            wheels.append(path)
+            violations.extend(_validate_wheel(path))
+        elif path.name.endswith((".tar.gz", ".tgz")):
+            sdists.append(path)
+            violations.extend(_validate_sdist(path))
+        else:
+            raise ReleaseValidationError(f"unsupported release artifact: {path}")
+
+    if len(wheels) != 1 or len(sdists) != 1:
+        raise ReleaseValidationError(
+            f"expected one wheel and one sdist; found {len(wheels)} wheel(s) "
+            f"and {len(sdists)} sdist(s)"
+        )
+    if violations:
+        raise ReleaseValidationError(
+            "uncontrolled contact domains in artifacts: " + ", ".join(violations)
+        )
+    _validate_core_metadata(wheels[0], _wheel_metadata(wheels[0]), expected_version)
+    _validate_core_metadata(sdists[0], _sdist_metadata(sdists[0]), expected_version)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Neural release inputs")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    classify_parser = subparsers.add_parser("classify-tag")
+    classify_parser.add_argument("tag")
+    classify_parser.add_argument("--project-file", type=Path, default=Path("pyproject.toml"))
+
+    source_parser = subparsers.add_parser("validate-source")
+    source_parser.add_argument("root", type=Path)
+
+    artifact_parser = subparsers.add_parser("validate-artifacts")
+    artifact_parser.add_argument("artifacts", nargs="+", type=Path)
+    artifact_parser.add_argument("--project-file", type=Path, default=Path("pyproject.toml"))
+
+    args = parser.parse_args()
+    try:
+        if args.command == "classify-tag":
+            print(f"channel={classify_tag(args.tag, project_version(args.project_file))}")
+        elif args.command == "validate-source":
+            validate_source(args.root)
+        else:
+            validate_artifacts(args.artifacts, project_version(args.project_file))
+    except ReleaseValidationError as exc:
+        parser.exit(2, f"release validation failed: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -10,15 +10,20 @@ from email.policy import default
 from pathlib import Path
 from typing import BinaryIO
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised by Python 3.10 CI
+    import tomli as tomllib
 
 _VERSION_CORE = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
-_SEMVER_IDENTIFIER = r"(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
 _STABLE_VERSION = re.compile(rf"^{_VERSION_CORE}$")
 _TEST_VERSION = re.compile(
-    rf"^{_VERSION_CORE}(?:(?:a|b|rc|dev)\d+|\.dev\d+"
-    rf"|-{_SEMVER_IDENTIFIER}(?:\.{_SEMVER_IDENTIFIER})*)$"
+    rf"^{_VERSION_CORE}(?:(?:a|b|rc)\d+|(?:\.?dev)\d+" rf"|-(?:alpha|beta|rc|dev)\.(?:0|[1-9]\d*))$"
 )
+_VERSION_ALIAS = re.compile(
+    rf"^(?P<core>{_VERSION_CORE})-(?P<label>alpha|beta|rc|dev)\.(?P<number>\d+)$"
+)
+_DEV_WITHOUT_DOT = re.compile(rf"^(?P<core>{_VERSION_CORE})dev(?P<number>\d+)$")
 
 _BLOCKED_DOMAINS = tuple(f"neural-sdk.{suffix}".encode("ascii") for suffix in ("dev", "com"))
 _EXPECTED_METADATA = {
@@ -41,6 +46,16 @@ _IGNORED_SOURCE_PARTS = {
 
 class ReleaseValidationError(ValueError):
     """Release input failed a deterministic safety check."""
+
+
+def normalized_artifact_version(version: str) -> str:
+    """Return the PEP 440 version setuptools writes into artifact metadata."""
+    if alias := _VERSION_ALIAS.fullmatch(version):
+        label = {"alpha": "a", "beta": "b", "rc": "rc", "dev": ".dev"}[alias.group("label")]
+        return f"{alias.group('core')}{label}{alias.group('number')}"
+    if dev := _DEV_WITHOUT_DOT.fullmatch(version):
+        return f"{dev.group('core')}.dev{dev.group('number')}"
+    return version
 
 
 def project_version(project_file: Path) -> str:
@@ -186,7 +201,7 @@ def _sdist_metadata(path: Path) -> bytes:
 
 def _validate_core_metadata(path: Path, content: bytes, expected_version: str) -> None:
     metadata = BytesParser(policy=default).parsebytes(content)
-    expected = {"Version": expected_version, **_EXPECTED_METADATA}
+    expected = {"Version": normalized_artifact_version(expected_version), **_EXPECTED_METADATA}
     mismatches = [
         f"{header}: expected {value!r}, found {metadata.get(header)!r}"
         for header, value in expected.items()

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -19,13 +19,8 @@ _VERSION_CORE = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
 _VERSION_NUMBER = r"(?:0|[1-9]\d*)"
 _STABLE_VERSION = re.compile(rf"^{_VERSION_CORE}$")
 _TEST_VERSION = re.compile(
-    rf"^{_VERSION_CORE}(?:(?:a|b|rc){_VERSION_NUMBER}|(?:\.?dev){_VERSION_NUMBER}"
-    rf"|-(?:alpha|beta|rc|dev)\.{_VERSION_NUMBER})$"
+    rf"^{_VERSION_CORE}(?:(?:a|b|rc){_VERSION_NUMBER}|\.dev{_VERSION_NUMBER})$"
 )
-_VERSION_ALIAS = re.compile(
-    rf"^(?P<core>{_VERSION_CORE})-(?P<label>alpha|beta|rc|dev)" rf"\.(?P<number>{_VERSION_NUMBER})$"
-)
-_DEV_WITHOUT_DOT = re.compile(rf"^(?P<core>{_VERSION_CORE})dev(?P<number>{_VERSION_NUMBER})$")
 
 _BLOCKED_DOMAINS = tuple(f"neural-sdk.{suffix}".encode("ascii") for suffix in ("dev", "com"))
 _EXPECTED_METADATA = {
@@ -48,16 +43,6 @@ _IGNORED_SOURCE_PARTS = {
 
 class ReleaseValidationError(ValueError):
     """Release input failed a deterministic safety check."""
-
-
-def normalized_artifact_version(version: str) -> str:
-    """Return the PEP 440 version setuptools writes into artifact metadata."""
-    if alias := _VERSION_ALIAS.fullmatch(version):
-        label = {"alpha": "a", "beta": "b", "rc": "rc", "dev": ".dev"}[alias.group("label")]
-        return f"{alias.group('core')}{label}{alias.group('number')}"
-    if dev := _DEV_WITHOUT_DOT.fullmatch(version):
-        return f"{dev.group('core')}.dev{dev.group('number')}"
-    return version
 
 
 def project_version(project_file: Path) -> str:
@@ -203,7 +188,7 @@ def _sdist_metadata(path: Path) -> bytes:
 
 def _validate_core_metadata(path: Path, content: bytes, expected_version: str) -> None:
     metadata = BytesParser(policy=default).parsebytes(content)
-    expected = {"Version": normalized_artifact_version(expected_version), **_EXPECTED_METADATA}
+    expected = {"Version": expected_version, **_EXPECTED_METADATA}
     mismatches = [
         f"{header}: expected {value!r}, found {metadata.get(header)!r}"
         for header, value in expected.items()

--- a/tests/test_contact_security.py
+++ b/tests/test_contact_security.py
@@ -17,16 +17,29 @@ CONTACT_SURFACES = (
 UNCONTROLLED_CONTACT_DOMAINS = ("neural-sdk.dev", "neural-sdk.com")
 
 
+def _find_uncontrolled_domains(relative_path: str, content: str) -> list[str]:
+    normalized_content = content.casefold()
+    return [
+        f"{relative_path}: {domain}"
+        for domain in UNCONTROLLED_CONTACT_DOMAINS
+        if domain.casefold() in normalized_content
+    ]
+
+
 def test_public_contact_surfaces_do_not_use_uncontrolled_domains() -> None:
     violations = []
 
     for relative_path in CONTACT_SURFACES:
         content = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
-        for domain in UNCONTROLLED_CONTACT_DOMAINS:
-            if domain in content:
-                violations.append(f"{relative_path}: {domain}")
+        violations.extend(_find_uncontrolled_domains(relative_path, content))
 
     assert not violations, "Uncontrolled contact domains found: " + ", ".join(violations)
+
+
+def test_uncontrolled_domain_detection_is_case_insensitive() -> None:
+    assert _find_uncontrolled_domains("synthetic.txt", "Contact EVIL@NEURAL-SDK.DEV") == [
+        "synthetic.txt: neural-sdk.dev"
+    ]
 
 
 def test_package_metadata_uses_accountable_maintainer_contact() -> None:

--- a/tests/test_contact_security.py
+++ b/tests/test_contact_security.py
@@ -1,45 +1,12 @@
 from pathlib import Path
 
+from scripts.validate_release import validate_source
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
-CONTACT_SURFACES = (
-    "pyproject.toml",
-    "CONTRIBUTING.md",
-    "CODE_OF_CONDUCT.md",
-    "docs/mint.json",
-    "docs/openapi/authentication-schemes.yaml",
-    "docs/openapi/data-collection-apis.yaml",
-    "docs/openapi/data-models.yaml",
-    "docs/openapi/fix-protocol.yaml",
-    "docs/openapi/kalshi-trading-api.yaml",
-    "docs/openapi/websocket-api.yaml",
-    "scripts/generate_openapi_specs.py",
-)
-UNCONTROLLED_CONTACT_DOMAINS = ("neural-sdk.dev", "neural-sdk.com")
 
 
-def _find_uncontrolled_domains(relative_path: str, content: str) -> list[str]:
-    normalized_content = content.casefold()
-    return [
-        f"{relative_path}: {domain}"
-        for domain in UNCONTROLLED_CONTACT_DOMAINS
-        if domain.casefold() in normalized_content
-    ]
-
-
-def test_public_contact_surfaces_do_not_use_uncontrolled_domains() -> None:
-    violations = []
-
-    for relative_path in CONTACT_SURFACES:
-        content = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
-        violations.extend(_find_uncontrolled_domains(relative_path, content))
-
-    assert not violations, "Uncontrolled contact domains found: " + ", ".join(violations)
-
-
-def test_uncontrolled_domain_detection_is_case_insensitive() -> None:
-    assert _find_uncontrolled_domains("synthetic.txt", "Contact EVIL@NEURAL-SDK.DEV") == [
-        "synthetic.txt: neural-sdk.dev"
-    ]
+def test_public_source_does_not_use_uncontrolled_domains() -> None:
+    validate_source(REPO_ROOT)
 
 
 def test_package_metadata_uses_accountable_maintainer_contact() -> None:

--- a/tests/test_contact_security.py
+++ b/tests/test_contact_security.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTACT_SURFACES = (
+    "pyproject.toml",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
+    "docs/mint.json",
+    "docs/openapi/authentication-schemes.yaml",
+    "docs/openapi/data-collection-apis.yaml",
+    "docs/openapi/data-models.yaml",
+    "docs/openapi/fix-protocol.yaml",
+    "docs/openapi/kalshi-trading-api.yaml",
+    "docs/openapi/websocket-api.yaml",
+    "scripts/generate_openapi_specs.py",
+)
+UNCONTROLLED_CONTACT_DOMAINS = ("neural-sdk.dev", "neural-sdk.com")
+
+
+def test_public_contact_surfaces_do_not_use_uncontrolled_domains() -> None:
+    violations = []
+
+    for relative_path in CONTACT_SURFACES:
+        content = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        for domain in UNCONTROLLED_CONTACT_DOMAINS:
+            if domain in content:
+                violations.append(f"{relative_path}: {domain}")
+
+    assert not violations, "Uncontrolled contact domains found: " + ", ".join(violations)
+
+
+def test_package_metadata_uses_accountable_maintainer_contact() -> None:
+    metadata = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert '{ name = "Hudson Aikins", email = "hudson@intelip.co" }' in metadata
+    assert '{ name = "Neural Contributors" }' in metadata
+    assert '{ name = "Advanced Intellectual Labs LLC", email = "hudson@intelip.co" }' in metadata

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -10,7 +10,6 @@ from scripts import package_smoke
 from scripts.validate_release import (
     ReleaseValidationError,
     classify_tag,
-    normalized_artifact_version,
     project_version,
     validate_artifacts,
     validate_source,
@@ -29,13 +28,10 @@ def test_stable_tags_route_only_to_pypi(tag: str) -> None:
 @pytest.mark.parametrize(
     "tag",
     [
+        "v0.4.2a1",
+        "v0.4.2b2",
         "v0.4.2rc1",
-        "v0.4.2dev1",
         "v0.4.2.dev1",
-        "v0.4.2-alpha.1",
-        "v0.4.2-beta.2",
-        "v0.4.2-rc.2",
-        "v0.4.2-dev.3",
     ],
 )
 def test_prerelease_and_dev_tags_route_only_to_testpypi(tag: str) -> None:
@@ -52,6 +48,11 @@ def test_prerelease_and_dev_tags_route_only_to_testpypi(tag: str) -> None:
         "v0.4.2+build",
         "v0.4.2.post1",
         "v0.4.2-preview.1",
+        "v0.4.2dev1",
+        "v0.4.2-alpha.1",
+        "v0.4.2-beta.2",
+        "v0.4.2-rc.2",
+        "v0.4.2-dev.3",
         "v0.4.2a01",
         "v0.4.2rc01",
         "v0.4.2dev01",
@@ -79,28 +80,23 @@ def test_project_version_reads_pyproject(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("project_version_value", "artifact_version"),
+    "version",
     [
-        ("0.4.2rc1", "0.4.2rc1"),
-        ("0.4.2dev1", "0.4.2.dev1"),
-        ("0.4.2.dev1", "0.4.2.dev1"),
-        ("0.4.2-alpha.1", "0.4.2a1"),
-        ("0.4.2-beta.2", "0.4.2b2"),
-        ("0.4.2-rc.2", "0.4.2rc2"),
-        ("0.4.2-dev.3", "0.4.2.dev3"),
+        "0.4.2a1",
+        "0.4.2b2",
+        "0.4.2rc1",
+        "0.4.2.dev1",
     ],
 )
-def test_artifact_versions_use_pep440_normalization(
-    tmp_path: Path, project_version_value: str, artifact_version: str
+def test_canonical_prerelease_versions_match_artifact_metadata(
+    tmp_path: Path, version: str
 ) -> None:
-    assert normalized_artifact_version(project_version_value) == artifact_version
-
     wheel = tmp_path / "neural_sdk-prerelease-py3-none-any.whl"
     sdist = tmp_path / "neural_sdk-prerelease.tar.gz"
-    _write_wheel(wheel, _metadata(version=artifact_version))
-    _write_sdist(sdist, _metadata(version=artifact_version))
+    _write_wheel(wheel, _metadata(version=version))
+    _write_sdist(sdist, _metadata(version=version))
 
-    validate_artifacts([wheel, sdist], project_version_value)
+    validate_artifacts([wheel, sdist], version)
 
 
 def test_package_smoke_uses_dynamic_prerelease_version(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -1,0 +1,175 @@
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_release import (
+    ReleaseValidationError,
+    classify_tag,
+    project_version,
+    validate_artifacts,
+    validate_source,
+)
+
+
+def _uncontrolled_contact(suffix: str) -> str:
+    return f"EVIL@NEURAL-SDK.{suffix}"
+
+
+@pytest.mark.parametrize("tag", ["v0.4.2", "v1.0.0", "v10.20.30"])
+def test_stable_tags_route_only_to_pypi(tag: str) -> None:
+    assert classify_tag(tag, tag.removeprefix("v")) == "pypi"
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "v0.4.2rc1",
+        "v0.4.2dev1",
+        "v0.4.2.dev1",
+        "v0.4.2-alpha.1",
+        "v0.4.2-beta.2",
+        "v0.4.2-dev.3",
+    ],
+)
+def test_prerelease_and_dev_tags_route_only_to_testpypi(tag: str) -> None:
+    assert classify_tag(tag, tag.removeprefix("v")) == "testpypi"
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "0.4.2",
+        "v0.4",
+        "v01.4.2",
+        "v0.4.2-01",
+        "v0.4.2+build",
+        "v0.4.2.post1",
+        "release-v0.4.2",
+    ],
+)
+def test_invalid_tags_are_rejected(tag: str) -> None:
+    with pytest.raises(ReleaseValidationError):
+        classify_tag(tag, tag.removeprefix("v"))
+
+
+@pytest.mark.parametrize("tag", ["v99.0.0", "v0.4.2rc1"])
+def test_tag_must_match_project_version(tag: str) -> None:
+    with pytest.raises(ReleaseValidationError, match="does not match project version"):
+        classify_tag(tag, "0.4.2")
+
+
+def test_project_version_reads_pyproject(tmp_path: Path) -> None:
+    project_file = tmp_path / "pyproject.toml"
+    project_file.write_text('[project]\nversion = "1.2.3rc1"\n', encoding="utf-8")
+
+    assert project_version(project_file) == "1.2.3rc1"
+
+
+def test_source_scan_is_recursive_and_ignores_test_fixtures(tmp_path: Path) -> None:
+    public_doc = tmp_path / "docs" / "nested" / "contact.md"
+    public_doc.parent.mkdir(parents=True)
+    public_doc.write_text("Contact hudson@intelip.co", encoding="utf-8")
+
+    intentional_fixture = tmp_path / "tests" / "fixtures" / "malicious.txt"
+    intentional_fixture.parent.mkdir(parents=True)
+    intentional_fixture.write_text(_uncontrolled_contact("DEV"), encoding="utf-8")
+
+    validate_source(tmp_path)
+
+    public_doc.write_text(_uncontrolled_contact("DEV"), encoding="utf-8")
+    with pytest.raises(ReleaseValidationError, match="docs/nested/contact.md"):
+        validate_source(tmp_path)
+
+
+def _metadata(
+    *,
+    version: str = "0.4.2",
+    author: str = "Hudson Aikins <hudson@intelip.co>",
+    maintainer: str = "Advanced Intellectual Labs LLC <hudson@intelip.co>",
+) -> bytes:
+    return (
+        f"Metadata-Version: 2.4\nVersion: {version}\n"
+        f"Author-email: {author}\nMaintainer-email: {maintainer}\n"
+    ).encode()
+
+
+def _write_wheel(path: Path, content: bytes) -> None:
+    with zipfile.ZipFile(path, mode="w") as archive:
+        archive.writestr("neural_sdk-0.4.2.dist-info/METADATA", content)
+
+
+def _write_sdist(path: Path, content: bytes) -> None:
+    with tarfile.open(path, mode="w:gz") as archive:
+        member = tarfile.TarInfo("neural_sdk-0.4.2/PKG-INFO")
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+
+
+def test_clean_wheel_and_sdist_pass(tmp_path: Path) -> None:
+    wheel = tmp_path / "neural_sdk-0.4.2-py3-none-any.whl"
+    sdist = tmp_path / "neural_sdk-0.4.2.tar.gz"
+    _write_wheel(wheel, _metadata())
+    _write_sdist(sdist, _metadata())
+
+    validate_artifacts([wheel, sdist], "0.4.2")
+
+
+@pytest.mark.parametrize("artifact_type", ["wheel", "sdist"])
+def test_mixed_case_uncontrolled_contacts_block_artifacts(
+    tmp_path: Path, artifact_type: str
+) -> None:
+    wheel = tmp_path / "neural_sdk-0.4.2-py3-none-any.whl"
+    sdist = tmp_path / "neural_sdk-0.4.2.tar.gz"
+    _write_wheel(
+        wheel,
+        _metadata()
+        + (
+            f"Contact: {_uncontrolled_contact('DEV')}".encode() if artifact_type == "wheel" else b""
+        ),
+    )
+    _write_sdist(
+        sdist,
+        _metadata()
+        + (
+            f"Contact: {_uncontrolled_contact('COM')}".encode() if artifact_type == "sdist" else b""
+        ),
+    )
+
+    with pytest.raises(ReleaseValidationError, match="uncontrolled contact domains"):
+        validate_artifacts([wheel, sdist], "0.4.2")
+
+
+@pytest.mark.parametrize(
+    ("wheel_metadata", "sdist_metadata", "match"),
+    [
+        (_metadata(version="9.9.9"), _metadata(), "Version"),
+        (_metadata(author="Attacker <attacker@example.org>"), _metadata(), "Author-email"),
+        (_metadata(), _metadata(maintainer="Attacker <attacker@example.org>"), "Maintainer-email"),
+        (_metadata(author=""), _metadata(), "Author-email"),
+    ],
+)
+def test_artifact_metadata_must_match_release_contract(
+    tmp_path: Path,
+    wheel_metadata: bytes,
+    sdist_metadata: bytes,
+    match: str,
+) -> None:
+    wheel = tmp_path / "neural_sdk-0.4.2-py3-none-any.whl"
+    sdist = tmp_path / "neural_sdk-0.4.2.tar.gz"
+    _write_wheel(wheel, wheel_metadata)
+    _write_sdist(sdist, sdist_metadata)
+
+    with pytest.raises(ReleaseValidationError, match=match):
+        validate_artifacts([wheel, sdist], "0.4.2")
+
+
+def test_publish_workflow_has_mutually_exclusive_uploads() -> None:
+    workflow = Path(".github/workflows/publish.yml").read_text(encoding="utf-8")
+
+    assert "steps.release.outputs.channel == 'pypi'" in workflow
+    assert "steps.release.outputs.channel == 'testpypi'" in workflow
+    assert workflow.count("twine upload") == 2
+    assert workflow.index("validate-artifacts") < workflow.index("twine upload")

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -1,10 +1,12 @@
 import io
+import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
 
 import pytest
 
+from scripts import package_smoke
 from scripts.validate_release import (
     ReleaseValidationError,
     classify_tag,
@@ -99,6 +101,23 @@ def test_artifact_versions_use_pep440_normalization(
     _write_sdist(sdist, _metadata(version=artifact_version))
 
     validate_artifacts([wheel, sdist], project_version_value)
+
+
+def test_package_smoke_uses_dynamic_prerelease_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        (
+            subprocess.CompletedProcess([], 0, stdout="0.4.2rc1\n", stderr=""),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                stdout='{"version": "0.4.2rc1", "credentials": {}, "optional_dependencies": {}}',
+                stderr="",
+            ),
+        )
+    )
+    monkeypatch.setattr(package_smoke.subprocess, "run", lambda *args, **kwargs: next(responses))
+
+    package_smoke._assert_clean_cli("0.4.2rc1")
 
 
 def test_source_scan_is_recursive_and_ignores_test_fixtures(tmp_path: Path) -> None:

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -8,6 +8,7 @@ import pytest
 from scripts.validate_release import (
     ReleaseValidationError,
     classify_tag,
+    normalized_artifact_version,
     project_version,
     validate_artifacts,
     validate_source,
@@ -31,6 +32,7 @@ def test_stable_tags_route_only_to_pypi(tag: str) -> None:
         "v0.4.2.dev1",
         "v0.4.2-alpha.1",
         "v0.4.2-beta.2",
+        "v0.4.2-rc.2",
         "v0.4.2-dev.3",
     ],
 )
@@ -47,6 +49,7 @@ def test_prerelease_and_dev_tags_route_only_to_testpypi(tag: str) -> None:
         "v0.4.2-01",
         "v0.4.2+build",
         "v0.4.2.post1",
+        "v0.4.2-preview.1",
         "release-v0.4.2",
     ],
 )
@@ -66,6 +69,31 @@ def test_project_version_reads_pyproject(tmp_path: Path) -> None:
     project_file.write_text('[project]\nversion = "1.2.3rc1"\n', encoding="utf-8")
 
     assert project_version(project_file) == "1.2.3rc1"
+
+
+@pytest.mark.parametrize(
+    ("project_version_value", "artifact_version"),
+    [
+        ("0.4.2rc1", "0.4.2rc1"),
+        ("0.4.2dev1", "0.4.2.dev1"),
+        ("0.4.2.dev1", "0.4.2.dev1"),
+        ("0.4.2-alpha.1", "0.4.2a1"),
+        ("0.4.2-beta.2", "0.4.2b2"),
+        ("0.4.2-rc.2", "0.4.2rc2"),
+        ("0.4.2-dev.3", "0.4.2.dev3"),
+    ],
+)
+def test_artifact_versions_use_pep440_normalization(
+    tmp_path: Path, project_version_value: str, artifact_version: str
+) -> None:
+    assert normalized_artifact_version(project_version_value) == artifact_version
+
+    wheel = tmp_path / "neural_sdk-prerelease-py3-none-any.whl"
+    sdist = tmp_path / "neural_sdk-prerelease.tar.gz"
+    _write_wheel(wheel, _metadata(version=artifact_version))
+    _write_sdist(sdist, _metadata(version=artifact_version))
+
+    validate_artifacts([wheel, sdist], project_version_value)
 
 
 def test_source_scan_is_recursive_and_ignores_test_fixtures(tmp_path: Path) -> None:

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -50,6 +50,11 @@ def test_prerelease_and_dev_tags_route_only_to_testpypi(tag: str) -> None:
         "v0.4.2+build",
         "v0.4.2.post1",
         "v0.4.2-preview.1",
+        "v0.4.2a01",
+        "v0.4.2rc01",
+        "v0.4.2dev01",
+        "v0.4.2.dev01",
+        "v0.4.2-alpha.01",
         "release-v0.4.2",
     ],
 )


### PR DESCRIPTION
## Problem

PyPI `neural-sdk` 0.4.1 publishes `contributors@neural-sdk.dev`, and public documentation uses `support@neural-sdk.com`. Both domains were found unregistered during the contact-security audit, creating expired-domain takeover and maintainer-impersonation risk.

The public 0.4.1 release line diverges from `main`. Applying the main-based fix directly would change the public package payload and dependency surface beyond this security hotfix.

## Outcome

This release-line candidate:

- advances the package version to 0.4.2;
- replaces uncontrolled Neural-domain contacts with accountable `intelip.co` contacts;
- adds case-insensitive regression tests for tracked source and built artifacts;
- preserves the 0.4.1 package payload and dependency contract;
- routes stable tags only to PyPI and canonical PEP 440 prerelease/dev tags only to TestPyPI;
- binds tag, project, artifact, runtime, CLI, and distribution-metadata versions without alias normalization;
- rejects ambiguous aliases and leading-zero prerelease numbers before build;
- derives smoke-test expectations from installed distribution metadata;
- supports release validation on Python 3.10 through the `tomli` compatibility fallback;
- keeps release-only tests out of the sdist because their validator tooling is intentionally not shipped.

## Acceptance Criteria

- [x] Built wheel and sdist identify version 0.4.2.
- [x] Package metadata and public contact surfaces contain no `neural-sdk.dev` or `neural-sdk.com`, including mixed-case variants.
- [x] Maintainer and author contacts use `hudson@intelip.co`.
- [x] Wheel preserves all 68 payload paths and all 36 dependency declarations from public 0.4.1.
- [x] Runtime package source is identical to 0.4.1 except for the version sentinel.
- [x] Trusted hosted workflow validates the exact candidate without publishing.

## Validation

Exact base: `9b80b424c34e25f86fb8280bd099e7473318ccde` (`v0.4.1` release commit)

Exact candidate: `585747cc9795d37e7e8b04d234f3e7955bc49153`

Passed on exact candidate:

- [trusted release validation run 30060718450](https://github.com/IntelIP/Neural/actions/runs/30060718450): authorization, build, source/artifact identity, wheel smoke, sdist smoke, evidence promotion;
- Python 3.10 full suite: 140 passed, 6 credential-dependent skips, 2 inherited warnings;
- focused contact and release-safety suite: 44 passed;
- Ruff full repository;
- Black for all changed Python files;
- MyPy across 67 runtime source files;
- wheel and sdist build;
- strict Twine validation;
- case-folded source and artifact contact scans;
- canonical PEP 440 prerelease acceptance and alias/leading-zero rejection regressions;
- dynamic prerelease smoke-version regression;
- sdist exclusion proof for release-only tests while ordinary downstream tests remain included;
- exact 68-file wheel layout and 36-declaration dependency compatibility with public 0.4.1;
- runtime source comparison showing only `neural/_version.py` changed from public 0.4.1;
- clean exact-head worktree.

Hosted artifacts:

- wheel SHA-256: `9a63b05f2228262327e374c6282f6ae818eccb93c2400f79a91903d31a13925c`
- sdist SHA-256: `2988c5db0214493078469b12ebb85da543dc32b650eb18d68cd63a786b252561`

## Review Findings Addressed

- Python 3.10 validator import compatibility;
- self-contained source distribution test set;
- rejection of ambiguous leading-zero prerelease numbers;
- dynamic installed-version expectations in publish smoke tests;
- canonical-only prerelease contract across project, artifact, runtime, and CLI versions.

## Residual Risk

The absolute repository Black gate remains failed by six untouched files inherited from 0.4.1. Changed Python files pass Black, and this candidate introduces no new formatting regression.

This PR intentionally targets the published 0.4.1 release branch, not `main`. Broader source-line reconciliation remains separate work.

Pinned first-party actions currently emit non-blocking Node 20 deprecation annotations under GitHub's Node 24 forced runtime. Default-branch Dependabot debt remains separate.

One excluded hosted run (`30060702867`) used a mistyped nonexistent SHA and failed checkout; it is not candidate evidence. Run `30060718450` is the exact-head evidence.

## Release Safety and Exclusions

Plane work item: `NRCL-28` / `NV-002`.

Merge approval does not authorize tag creation, TestPyPI/PyPI publication, deployment, DNS changes, billing, infrastructure, secrets, or live-money actions. Publication remains a separate explicit gate.